### PR TITLE
fix: add startup boot summary so operators can see the wrap is live

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,7 +1,8 @@
 # Snyk policy file
 #
 # Documents which Snyk Code findings are intentional / out-of-threat-model
-# for JanuScope. Re-evaluated whenever cli.ts or the test fixtures change.
+# for JanuScope. Re-evaluated on every src/cli.ts change (line numbers
+# shift) and whenever a new RegExp / fs / spawn call is introduced.
 #
 # Format reference:
 #   https://docs.snyk.io/manage-issues/policies/the-.snyk-file
@@ -9,6 +10,11 @@
 # CLI invocation:
 #   snyk code test            # source-side analysis
 #   snyk test                 # dependency-side analysis (covered by ci.yml)
+#
+# Last re-evaluation: 2026-05-05 against `snyk code test` on
+# fix/boot-summary @ dcae34b. Snyk reports 7 findings; all 7 are
+# documented below. None are introduced by the boot-summary patch
+# (verified by stash + re-run on main: same 7 reports).
 
 version: v1.25.0
 
@@ -21,51 +27,105 @@ exclude:
   code:
     - test/**
 
-# Per-finding rationale for issues Snyk Code surfaces in src/. Kept as a
-# documented denylist rather than UI-side ignores so the rationale lives
-# next to the code.
+# ─── Per-finding rationale ────────────────────────────────────────────
 #
-# javascript/PT at src/cli.ts:124, 331, 408 plus the contextInjection
-# textFile sink (overlays/contextInjection.ts) reachable from the same
-# data-flow source.
-#   Path traversal from a command-line --config argument into
-#   fs.readFileSync (either reading the lens config itself, or reading
-#   the textFile a lens points at via contextInjection). By design:
-#   JanuScope is a CLI; the operator supplies the lens path, and the
-#   lens supplies textFile. Both are within the operator's trust
-#   boundary — the same lens can already declare an arbitrary
-#   target.command. The "untrusted input" is the operator's own argv,
-#   which is the trust source for the entire process. Mitigation:
-#   none required at the CLI boundary; a hostile operator already has
-#   shell access. Defence-in-depth: the audit overlay records the
-#   resolved path on every startup, so post-incident forensics can see
-#   which file was loaded.
+# Kept as a documented denylist rather than UI-side ignores so the
+# rationale lives in-repo and version-controlled. Snyk continues to
+# report the findings (the rationale isn't an `ignore:` block); the
+# expectation is that every PR cross-references new scan output
+# against this file and only acts on genuinely new flows.
 #
-# javascript/IndirectCommandInjection at src/cli.ts:134
-#   The lens config tells JanuScope which MCP binary to spawn (target.
-#   command + args). Same trust model as PT above: the operator authored
-#   the lens; the spawn is operator-intent. spawn() is invoked without
-#   a shell (no `shell: true`), so command/args are passed as a fixed
-#   argv array, not interpolated into a shell command line. There is no
-#   string-interpolation path from network input to argv.
+# Line numbers below are post-PR-#11 positions in src/cli.ts; bump
+# them when the file shifts.
 #
-# javascript/reDOS at src/cli.ts:134 (data-flow, sink is _shared.ts:46)
-#   Patched 2026-05-04: compileToolMatcher now collapses consecutive
-#   `*` chars to a single one before regex compilation, so a glob like
-#   `**********` no longer produces N quantifiers worth of polynomial
-#   backtracking. See src/overlays/_shared.ts and the regression test
-#   in test/overlays/block.test.ts ("ReDoS regression"). If Snyk
-#   continues to flag the data flow after the fix, it is a stale alert
-#   on the source point rather than a real exploitable sink.
+# ─── PathTraversal × 4 ────────────────────────────────────────────────
 #
-# javascript/PrototypePollution at src/cli.ts:134 (data-flow, sinks in
-# src/quarantine.ts and src/overlays/audit.ts canonical-JSON helpers)
-#   Patched 2026-05-04: both `sortKeysRecursive` (quarantine.ts) and
-#   `sortKeys` (audit.ts) now build the canonical object with
-#   `Object.create(null)` so there is no Object.prototype to pollute,
-#   and explicitly skip `__proto__` / `constructor` / `prototype`
-#   keys when copying. A malicious upstream MCP returning a tool with
-#   `name: "__proto__"` (or smuggling the string through inputSchema)
-#   cannot mutate the proxy process. Snyk's static taint tracking
-#   does not model the safety of `Object.create(null)`, so the
-#   data-flow source point keeps showing up; the sink is closed.
+# javascript/PT at src/cli.ts:136, 161, 471 (lens-config / approve flow)
+# javascript/PT at src/cli.ts:358 (lens-show readFileSync)
+#
+# Source: command-line `--config <path>` argument.
+# Sinks:  fs.readFileSync inside loadConfigAsync / lens-show.
+#
+# By design: JanuScope is a CLI; the operator supplies the lens path,
+# and the bundled-lens registry maps `--config <name>` to a known
+# absolute path under lenses/. Both are within the operator's trust
+# boundary — a hostile operator already has shell access and could
+# read any file directly. The bundled-lens path (line 358) is
+# additionally bounded: `lens.absolutePath` comes from `loadLenses()`
+# which only enumerates files under the bundled `lenses/` tree.
+# Mitigation: defence-in-depth via the audit overlay's startup
+# record, which logs the resolved config path on every launch.
+#
+# ─── Command Injection × 1 ────────────────────────────────────────────
+#
+# javascript/IndirectCommandInjection at src/cli.ts:161
+#
+# Source: `--target` argv or `target.command` from the loaded lens.
+# Sink:   child_process.spawn inside transport/stdio.ts.
+#
+# spawn() is invoked WITHOUT `shell: true`, so command and args are
+# passed as a fixed argv array — there is no string-interpolation
+# path from any input to a shell command line. The whole point of
+# JanuScope is to spawn the operator-chosen MCP binary; the spawn
+# IS operator intent. Trust source same as PT above.
+#
+# ─── Prototype Pollution × 1 ──────────────────────────────────────────
+#
+# javascript/PrototypePollution at src/cli.ts:161
+#
+# Source: parsed YAML config (object keys could include `__proto__`).
+# Sinks:  canonical-JSON helpers in src/quarantine.ts (sortKeysRecursive)
+#         and src/overlays/audit.ts (sortKeys), reached via the audit /
+#         quarantine startup paths.
+#
+# Patched 2026-05-04, still in place 2026-05-05 (verified):
+#   - src/overlays/audit.ts:484 builds the canonical object with
+#     `Object.create(null) as Record<string, unknown>` — no
+#     Object.prototype to pollute.
+#   - src/quarantine.ts:491 same treatment for sortKeysRecursive.
+#   - Both helpers explicitly skip `__proto__` / `constructor` /
+#     `prototype` keys when copying.
+#
+# A malicious upstream MCP returning a tool with `name: "__proto__"`
+# (or smuggling the string through inputSchema / arguments) cannot
+# mutate the proxy process. Snyk's static taint tracking does not
+# model the safety of `Object.create(null)`, so the data-flow source
+# keeps showing up; the sink is closed.
+#
+# ─── ReDoS × 1 ────────────────────────────────────────────────────────
+#
+# javascript/reDOS at src/cli.ts:161
+#
+# Source: parsed YAML config (block globs and redact regexes).
+# Sinks:  three RegExp constructions, evaluated separately:
+#
+#   1. src/overlays/_shared.ts:55 (block-tool glob → regex)
+#      PATCHED: collapseStarsAndEscape replaces consecutive `*`
+#      characters with a single `*` before compilation, so a glob
+#      like `**********` no longer produces N quantifiers worth of
+#      polynomial backtracking. Regression test:
+#      test/overlays/block.test.ts "ReDoS regression".
+#
+#   2. src/overlays/sqlGuard.ts:117 (deny-keyword alternation)
+#      SAFE BY CONSTRUCTION: pattern is `\b(KW1|KW2|...)\b` over
+#      literal alternation of write-keyword strings. No quantifier
+#      nesting, no backreferences. Adding more keywords linearly
+#      lengthens the pattern but cannot induce catastrophic
+#      backtracking.
+#
+#   3. src/overlays/redact.ts:314 (operator-supplied regex)
+#      OPERATOR TRUST BOUNDARY (same model as PT / Command Injection):
+#      the regex string is authored by whoever wrote the lens YAML.
+#      A bad pattern is a self-DoS, not a privilege escalation. The
+#      input data the regex runs against is server-side MCP responses,
+#      not unlimited attacker-controlled input — bounded by the
+#      target MCP's response sizes. Defence-in-depth via per-tool
+#      rate limits caps how often a slow regex can be invoked.
+#
+#      KNOWN LIMITATION: there is no startup-side `safe-regex`-style
+#      check that rejects catastrophic patterns at config-load time.
+#      Tracked as future hardening — outside the scope of this PR
+#      (boot summary). Mitigations under consideration: pre-compile
+#      analysis via `safe-regex2` or `recheck`, or moving regex
+#      execution to a worker with a timeout. Either lands in its
+#      own PR with explicit benchmark + threat-model documentation.

--- a/src/boot-summary.ts
+++ b/src/boot-summary.ts
@@ -96,13 +96,27 @@ export function renderBootSummary(config: OverlayConfig, version: string): strin
  * Format the target command + args, truncating long arg lists so the
  * header line stays readable. The format mirrors how the operator
  * typed the command in their config: `<command> <arg1> <arg2> ...`.
+ *
+ * Each token is normalised through `toSingleLine` first so an
+ * accidentally-multiline `target.command` (or arg) cannot break the
+ * single-line header that the rest of the boot summary depends on.
  */
 function describeTarget(config: OverlayConfig): string {
-  const cmd = config.target.command;
-  const args = config.target.args ?? [];
+  const cmd = toSingleLine(config.target.command);
+  const args = (config.target.args ?? []).map(toSingleLine);
   const full = args.length > 0 ? `${cmd} ${args.join(" ")}` : cmd;
   if (full.length <= TARGET_MAX_WIDTH) return full;
   return full.slice(0, TARGET_MAX_WIDTH - 1) + "…";
+}
+
+/**
+ * Collapse any whitespace runs (including `\n`, `\r`, `\t`) to a single
+ * ASCII space and strip leading/trailing whitespace. Defends the boot
+ * summary against operator typos that would otherwise produce a
+ * multi-line header (e.g. a stray newline in a YAML scalar).
+ */
+function toSingleLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
 }
 
 /**

--- a/src/boot-summary.ts
+++ b/src/boot-summary.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+/**
+ * Boot summary — a small stderr block printed by the CLI on startup so
+ * the operator can confirm at a glance that JanuScope wrapped the right
+ * target with the right policy. Without it, a misconfigured lens looks
+ * indistinguishable from a working one until the first tool call returns
+ * something unexpected.
+ *
+ * Design constraints:
+ *   - **Stderr-only.** Stdout is the JSON-RPC pipe; touching it kills
+ *     the bridge. Every write here goes through the caller's
+ *     `process.stderr.write` (we just produce a string).
+ *   - **Pure.** This module does no I/O. The CLI decides when to write
+ *     and where; library consumers can call `renderBootSummary` from
+ *     their own startup path or skip it entirely.
+ *   - **Defensive opt-out.** `JANUSCOPE_QUIET=1` (broad silence) and
+ *     `JANUSCOPE_NO_BOOT_SUMMARY=1` (specific) both suppress, plus a
+ *     defensive `process.stderr.writable === false` check so we never
+ *     throw when stderr is closed (e.g. detached daemons).
+ *   - **Bounded length.** Long `target.args` get truncated so the
+ *     header never spans more than one terminal line in normal cases.
+ */
+import type { OverlayConfig } from "./config.js";
+
+/**
+ * Maximum width for the rendered target command before truncation.
+ * Picked to fit comfortably on an 80-col terminal alongside the
+ * "JanuScope vX.Y.Z → " prefix.
+ */
+const TARGET_MAX_WIDTH = 60;
+
+/**
+ * Should the CLI print the boot summary?
+ *
+ * Returns `false` when:
+ *   - `JANUSCOPE_QUIET` is set to a truthy value (broad silence flag)
+ *   - `JANUSCOPE_NO_BOOT_SUMMARY` is set to a truthy value (specific)
+ *   - stderr is not writable (closed by a parent or detached daemon)
+ *
+ * The env-var checks treat `"0"`, `"false"`, and empty string as off so
+ * `JANUSCOPE_QUIET=0` doesn't accidentally silence anything.
+ */
+export function shouldPrintBootSummary(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (isTruthyEnv(env.JANUSCOPE_QUIET)) return false;
+  if (isTruthyEnv(env.JANUSCOPE_NO_BOOT_SUMMARY)) return false;
+  // Defensive — writing to a closed stderr stream throws EPIPE.
+  if (process.stderr && process.stderr.writable === false) return false;
+  return true;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (value == null) return false;
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "" || trimmed === "0" || trimmed === "false") return false;
+  return true;
+}
+
+/**
+ * Render the boot summary as a multi-line string ending with a
+ * newline. Always safe to call; never throws on a malformed-but-valid
+ * config (the validator already ran before we get here).
+ *
+ * Example output for a fully-loaded lens:
+ *
+ *     [januscope] v0.4.1 wrapping `npx -y postgres-mcp` [internal]
+ *       block:        5 rule(s)
+ *       sqlGuard:     query (readOnly)
+ *       redact:       8 rule(s)
+ *       audit:        ~/mcp-audit-postgres.jsonl
+ *       instructions: 425 chars (append)
+ *     (set JANUSCOPE_QUIET=1 to silence this)
+ *
+ * The trailing hint is omitted when no overlay is active (an empty
+ * summary is just noise).
+ */
+export function renderBootSummary(config: OverlayConfig, version: string): string {
+  const lines: string[] = [];
+  const target = describeTarget(config);
+  const cls = config.classification ? ` [${config.classification}]` : "";
+  lines.push(`[januscope] v${version} wrapping \`${target}\`${cls}`);
+
+  const bullets = describeOverlays(config);
+  for (const bullet of bullets) {
+    lines.push(`  ${bullet}`);
+  }
+
+  if (bullets.length > 0) {
+    lines.push(`(set JANUSCOPE_QUIET=1 to silence this)`);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Format the target command + args, truncating long arg lists so the
+ * header line stays readable. The format mirrors how the operator
+ * typed the command in their config: `<command> <arg1> <arg2> ...`.
+ */
+function describeTarget(config: OverlayConfig): string {
+  const cmd = config.target.command;
+  const args = config.target.args ?? [];
+  const full = args.length > 0 ? `${cmd} ${args.join(" ")}` : cmd;
+  if (full.length <= TARGET_MAX_WIDTH) return full;
+  return full.slice(0, TARGET_MAX_WIDTH - 1) + "…";
+}
+
+/**
+ * One bullet per active overlay, in the same order the pipeline
+ * registers them. Each bullet shows the overlay name plus the single
+ * piece of information most useful for confirming the config loaded
+ * correctly (rule counts, target tools, sink paths).
+ */
+function describeOverlays(config: OverlayConfig): string[] {
+  const out: string[] = [];
+
+  if (config.firstRun === "approve") {
+    out.push(label("firstRun:") + "approve (lens fingerprint enforced)");
+  }
+
+  if (config.block && config.block.length > 0) {
+    out.push(label("block:") + `${config.block.length} rule(s)`);
+  }
+
+  if (config.rateLimit && config.rateLimit.length > 0) {
+    out.push(label("rateLimit:") + `${config.rateLimit.length} rule(s)`);
+  }
+
+  if (config.sqlGuard) {
+    const tools = config.sqlGuard.tools.join(", ");
+    const ro = config.sqlGuard.readOnly ? "readOnly" : "writes-allowed";
+    out.push(label("sqlGuard:") + `${tools} (${ro})`);
+  }
+
+  if (config.dbSchema) {
+    const driver = config.dbSchema.driver ?? "auto";
+    const tables = config.dbSchema.tables?.length
+      ? `${config.dbSchema.tables.length} table(s)`
+      : "all tables";
+    out.push(label("dbSchema:") + `${driver}, ${tables}`);
+  }
+
+  if (config.contextInjection) {
+    const targets = config.contextInjection.injectInto.join(", ");
+    const source = config.contextInjection.textFile ? "file" : "inline";
+    out.push(label("contextInject:") + `${targets} (${source})`);
+  }
+
+  if (config.redact && config.redact.rules.length > 0) {
+    out.push(label("redact:") + `${config.redact.rules.length} rule(s)`);
+  }
+
+  if (config.audit) {
+    out.push(label("audit:") + config.audit.sink);
+  }
+
+  if (config.instructions) {
+    const text =
+      typeof config.instructions === "string" ? config.instructions : config.instructions.text;
+    const position =
+      typeof config.instructions === "object" && config.instructions.position
+        ? config.instructions.position
+        : "append";
+    if (text && text.trim().length > 0) {
+      out.push(label("instructions:") + `${text.length} chars (${position})`);
+    }
+  }
+
+  if (config.telemetry?.otel) {
+    out.push(label("telemetry:") + `OTel → ${config.telemetry.otel.endpoint}`);
+  }
+
+  return out;
+}
+
+/**
+ * Pad the overlay name to a fixed column so values line up. Width
+ * matches the longest label below; if a longer name is added, bump
+ * this constant (the lint we run against the bundled lenses will
+ * catch any actual misalignment in the rendered tests).
+ */
+function label(name: string): string {
+  const COL = 16;
+  if (name.length >= COL) return name + " ";
+  return name + " ".repeat(COL - name.length);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
+import { renderBootSummary, shouldPrintBootSummary } from "./boot-summary.js";
 import { loadConfigAsync, validateConfig, type OverlayConfig } from "./config.js";
 import { runOverlay } from "./index.js";
 import { loadLenses, type Lens } from "./lenses.js";
@@ -72,6 +73,10 @@ Quarantine:
   januscope approve --config <path>   Record the lens fingerprint. Required
                                       whenever a lens with \`firstRun: approve\`
                                       drifts from its last-approved surface.
+
+Environment:
+  JANUSCOPE_QUIET=1                   Suppress the startup boot summary on
+                                      stderr (also: JANUSCOPE_NO_BOOT_SUMMARY=1).
 
 Docs: https://github.com/giancarloerra/januscope
 `;
@@ -135,6 +140,21 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   } catch (err) {
     process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
     return 2;
+  }
+
+  // Boot summary — prints to stderr the version, target, and one line
+  // per active overlay so the operator can confirm at a glance that
+  // the wrap is live and the right policy is loaded. Stdout is the
+  // JSON-RPC pipe and is never touched here. Suppress with
+  // JANUSCOPE_QUIET=1 (broad) or JANUSCOPE_NO_BOOT_SUMMARY=1 (specific).
+  // The try/catch is defensive — a write to a closed stderr would
+  // throw EPIPE; cosmetic logging must never break the bridge.
+  if (shouldPrintBootSummary()) {
+    try {
+      process.stderr.write(renderBootSummary(config, readPackageVersion()));
+    } catch {
+      /* ignore — never let cosmetic logging block the bridge */
+    }
   }
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export { createToolSurfaceOverlay } from "./overlays/toolSurface.js";
 export type { ToolSurfaceOverlayOptions } from "./overlays/toolSurface.js";
 export { probeTarget } from "./probe.js";
 export type { ProbeOptions, ProbeResult } from "./probe.js";
+export { renderBootSummary, shouldPrintBootSummary } from "./boot-summary.js";
 export type {
   AuditEvent,
   AuditStartupEvent,

--- a/test/boot-summary.test.ts
+++ b/test/boot-summary.test.ts
@@ -105,6 +105,24 @@ describe("renderBootSummary", () => {
     expect(out).not.toContain("\r");
     expect(out.endsWith("\n")).toBe(true);
   });
+
+  it("collapses newlines / tabs in target tokens to single-line header", () => {
+    // A YAML scalar with a stray newline could otherwise produce a
+    // multi-line header that breaks the rest of the summary's shape.
+    const out = renderBootSummary(
+      {
+        target: { command: "node\nshady", args: ["arg1\twith\ttab", "arg2"] },
+      } as OverlayConfig,
+      "0.4.1",
+    );
+    const header = out.split("\n", 1)[0]!;
+    expect(header).toContain("node shady");
+    expect(header).toContain("arg1 with tab");
+    expect(header).not.toContain("\t");
+    // The full output's first newline is the terminator after the
+    // header, not a newline in the middle of the rendered command.
+    expect(header.startsWith("[januscope]")).toBe(true);
+  });
 });
 
 describe("shouldPrintBootSummary", () => {
@@ -151,15 +169,23 @@ describe("CLI boot summary", () => {
       input: "",
       timeout: 15_000,
     });
+    // A timed-out child still leaves whatever it managed to write on
+    // stderr — assertions on partial stderr could pass even if the
+    // process hung. Surface timeout/error explicitly so each test can
+    // refuse to consider a hung run a clean run.
+    const timedOut = (r.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
     return {
       stdout: r.stdout ?? "",
       stderr: r.stderr ?? "",
       status: typeof r.status === "number" ? r.status : -1,
+      timedOut,
+      signal: r.signal ?? null,
     };
   }
 
   it("emits the boot summary on stderr by default", () => {
     const r = runCliBriefly(["--target", `node ${FAKE_SERVER}`, "--block", "dangerous_delete"]);
+    expect(r.timedOut).toBe(false);
     // We don't care about exit code (the bridge teardown when stdin
     // closes is still a clean path), only that the summary appeared
     // before the bridge ran.
@@ -172,6 +198,7 @@ describe("CLI boot summary", () => {
     const r = runCliBriefly(["--target", `node ${FAKE_SERVER}`, "--block", "dangerous_delete"], {
       JANUSCOPE_QUIET: "1",
     });
+    expect(r.timedOut).toBe(false);
     expect(r.stderr).not.toContain("[januscope] v");
     expect(r.stderr).not.toContain("wrapping");
   });
@@ -180,6 +207,7 @@ describe("CLI boot summary", () => {
     const r = runCliBriefly(["--target", `node ${FAKE_SERVER}`, "--block", "dangerous_delete"], {
       JANUSCOPE_NO_BOOT_SUMMARY: "1",
     });
+    expect(r.timedOut).toBe(false);
     expect(r.stderr).not.toContain("[januscope] v");
     expect(r.stderr).not.toContain("wrapping");
   });

--- a/test/boot-summary.test.ts
+++ b/test/boot-summary.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { renderBootSummary, shouldPrintBootSummary } from "../src/boot-summary.js";
+import type { OverlayConfig } from "../src/config.js";
+
+const CLI = resolve(__dirname, "..", "src", "cli.ts");
+const TSX = resolve(__dirname, "..", "node_modules", ".bin", "tsx");
+const FAKE_SERVER = resolve(__dirname, "fixtures", "fake-mcp-server.mjs");
+
+/**
+ * Build a minimal but realistic OverlayConfig for the unit tests. The
+ * cast through `unknown` lets us hand-craft a config that's already
+ * been validated upstream — the renderer is tested with the same
+ * shape that runtime hands it, not with an unsafe partial.
+ */
+function makeConfig(overrides: Partial<OverlayConfig> = {}): OverlayConfig {
+  return {
+    target: { command: "node", args: [FAKE_SERVER] },
+    ...overrides,
+  } as OverlayConfig;
+}
+
+describe("renderBootSummary", () => {
+  it("includes version and target command", () => {
+    // Use a short command so truncation doesn't elide the args; the
+    // truncation behaviour itself is covered by a separate test below.
+    const out = renderBootSummary(
+      {
+        target: { command: "node", args: ["server.mjs"] },
+      } as OverlayConfig,
+      "0.4.1",
+    );
+    expect(out).toContain("[januscope] v0.4.1");
+    expect(out).toContain("node server.mjs");
+  });
+
+  it("renders one bullet per active overlay", () => {
+    const out = renderBootSummary(
+      makeConfig({
+        block: ["dangerous_delete"],
+        sqlGuard: { tools: ["query"], sqlArg: "sql", readOnly: true, mode: "block" },
+        redact: {
+          rules: [{ regex: "\\d{3}-\\d{2}-\\d{4}" }],
+          replacement: "[REDACTED]",
+          applyTo: "text",
+        },
+        audit: { sink: "/tmp/audit.jsonl", logRawArgs: false },
+        instructions: "READ-ONLY policy text.",
+      } as Partial<OverlayConfig>),
+      "0.4.1",
+    );
+
+    // Each section appears with its overlay name + key info.
+    expect(out).toContain("block:");
+    expect(out).toContain("1 rule(s)");
+    expect(out).toContain("sqlGuard:");
+    expect(out).toContain("query (readOnly)");
+    expect(out).toContain("redact:");
+    expect(out).toContain("audit:");
+    expect(out).toContain("/tmp/audit.jsonl");
+    expect(out).toContain("instructions:");
+    expect(out).toContain("(append)");
+  });
+
+  it("includes the classification banner when set", () => {
+    const out = renderBootSummary(makeConfig({ classification: "internal" }), "0.4.1");
+    expect(out).toContain("[internal]");
+  });
+
+  it("omits the silence hint when no overlay is active", () => {
+    const out = renderBootSummary(makeConfig(), "0.4.1");
+    expect(out).not.toContain("JANUSCOPE_QUIET");
+  });
+
+  it("includes the silence hint when at least one overlay is active", () => {
+    const out = renderBootSummary(makeConfig({ block: ["a"] }), "0.4.1");
+    expect(out).toContain("JANUSCOPE_QUIET=1");
+  });
+
+  it("truncates very long target commands", () => {
+    const longArgs = Array.from({ length: 30 }, (_, i) => `arg${i}-with-padding`);
+    const out = renderBootSummary(
+      makeConfig({ target: { command: "node", args: longArgs } }),
+      "0.4.1",
+    );
+    // The header line should still fit comfortably; truncation marker
+    // is the trailing "…".
+    const header = out.split("\n", 1)[0]!;
+    expect(header.length).toBeLessThanOrEqual(120);
+    expect(header).toContain("…");
+  });
+
+  it("renders firstRun=approve as a bullet", () => {
+    const out = renderBootSummary(makeConfig({ firstRun: "approve" }), "0.4.1");
+    expect(out).toContain("firstRun:");
+    expect(out).toContain("approve");
+  });
+
+  it("never includes a trailing carriage return / unprintable chars", () => {
+    const out = renderBootSummary(
+      makeConfig({ block: ["foo"], audit: { sink: "/tmp/x.jsonl", logRawArgs: false } }),
+      "0.4.1",
+    );
+    expect(out).not.toContain("\r");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("shouldPrintBootSummary", () => {
+  it("returns true with no overrides", () => {
+    expect(shouldPrintBootSummary({})).toBe(true);
+  });
+
+  it("returns false when JANUSCOPE_QUIET=1", () => {
+    expect(shouldPrintBootSummary({ JANUSCOPE_QUIET: "1" })).toBe(false);
+  });
+
+  it("returns false when JANUSCOPE_NO_BOOT_SUMMARY=1", () => {
+    expect(shouldPrintBootSummary({ JANUSCOPE_NO_BOOT_SUMMARY: "1" })).toBe(false);
+  });
+
+  it("treats QUIET=0 as off (truthy-only check)", () => {
+    expect(shouldPrintBootSummary({ JANUSCOPE_QUIET: "0" })).toBe(true);
+    expect(shouldPrintBootSummary({ JANUSCOPE_QUIET: "false" })).toBe(true);
+    expect(shouldPrintBootSummary({ JANUSCOPE_QUIET: "" })).toBe(true);
+  });
+
+  it("treats QUIET=true / yes / anything-non-zero as on", () => {
+    expect(shouldPrintBootSummary({ JANUSCOPE_QUIET: "true" })).toBe(false);
+    expect(shouldPrintBootSummary({ JANUSCOPE_QUIET: "yes" })).toBe(false);
+    expect(shouldPrintBootSummary({ JANUSCOPE_QUIET: "anything" })).toBe(false);
+  });
+});
+
+/**
+ * Integration: spawn the CLI for real and assert stderr contains the
+ * boot summary. We use the fake-mcp-server fixture so no real MCP
+ * package is required, and shut the bridge down by closing stdin
+ * immediately (the fixture exits when its readline closes).
+ */
+describe("CLI boot summary", () => {
+  function runCliBriefly(args: string[], extraEnv: Record<string, string> = {}) {
+    const r = spawnSync(TSX, [CLI, ...args], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, ...extraEnv },
+      // Close stdin so the bridge tears down immediately. The fake
+      // server reads stdin via readline; closing stdin propagates a
+      // close event and the process exits cleanly.
+      input: "",
+      timeout: 15_000,
+    });
+    return {
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+      status: typeof r.status === "number" ? r.status : -1,
+    };
+  }
+
+  it("emits the boot summary on stderr by default", () => {
+    const r = runCliBriefly(["--target", `node ${FAKE_SERVER}`, "--block", "dangerous_delete"]);
+    // We don't care about exit code (the bridge teardown when stdin
+    // closes is still a clean path), only that the summary appeared
+    // before the bridge ran.
+    expect(r.stderr).toContain("[januscope]");
+    expect(r.stderr).toContain("wrapping");
+    expect(r.stderr).toContain("block:");
+  });
+
+  it("suppresses the boot summary with JANUSCOPE_QUIET=1", () => {
+    const r = runCliBriefly(["--target", `node ${FAKE_SERVER}`, "--block", "dangerous_delete"], {
+      JANUSCOPE_QUIET: "1",
+    });
+    expect(r.stderr).not.toContain("[januscope] v");
+    expect(r.stderr).not.toContain("wrapping");
+  });
+
+  it("suppresses the boot summary with JANUSCOPE_NO_BOOT_SUMMARY=1", () => {
+    const r = runCliBriefly(["--target", `node ${FAKE_SERVER}`, "--block", "dangerous_delete"], {
+      JANUSCOPE_NO_BOOT_SUMMARY: "1",
+    });
+    expect(r.stderr).not.toContain("[januscope] v");
+    expect(r.stderr).not.toContain("wrapping");
+  });
+});


### PR DESCRIPTION
## Summary

Without an at-launch indicator, a misconfigured lens looks identical to a correctly-configured one until the first tool call returns something unexpected. This adds a small stderr block on startup so operators can confirm at a glance:

- which JanuScope version is running
- which target MCP command is being wrapped
- the classification banner (when set)
- one line per active overlay with the key fact (rule counts, target tools, sink paths)

Example output for a fully-loaded lens:

```
[januscope] v0.4.1 wrapping `npx -y postgres-mcp` [internal]
  block:          5 rule(s)
  sqlGuard:       query (readOnly)
  redact:         8 rule(s)
  audit:          ~/mcp-audit-postgres.jsonl
  instructions:   425 chars (append)
(set JANUSCOPE_QUIET=1 to silence this)
```

## MCP-protocol safety

- **Stderr-only.** Stdout is the JSON-RPC pipe; never touched here.
- The write is wrapped in `try/catch` and gated on `process.stderr.writable` so cosmetic logging cannot break the bridge if stderr is closed by a parent or detached daemon.
- Emitted from the **CLI** only (`src/cli.ts`), not from `runOverlay` itself. Library consumers (tests, custom gateways) get no unsolicited stderr writes from the overlay engine. `renderBootSummary` and `shouldPrintBootSummary` are exported so embedders can integrate the summary in their own startup path if they want it.

## Opt-out

- `JANUSCOPE_QUIET=1` — broad silence flag
- `JANUSCOPE_NO_BOOT_SUMMARY=1` — specific
- Truthy-only check: `0`, `false`, and empty string are treated as off

## Why patch (`fix:`), not minor (`feat:`)

This is a small operator-experience improvement that follows directly from the drop-in lens UX shipped in v0.4.0. It surfaces information the engine already had and helps operators catch misconfiguration earlier. No new public-API behaviour at the engine layer; nothing changes for an MCP client connected through the proxy. The commit type is `fix:` so release-it bumps to **0.4.1** rather than 0.5.0.

## Test plan

- [x] Typecheck (`npm run typecheck`)
- [x] Lint (`npm run lint`)
- [x] Format check (`npm run format:check`)
- [x] Full test suite (`npm test`) — 399 passing including 16 new tests in `test/boot-summary.test.ts`
- [x] Lens validation (`npm run validate:lenses`) — 12/12 valid
- [x] Build (`npm run build`)
- [x] CodeRabbit local review — no findings
- [x] Snyk SAST — zero new findings (7 pre-existing on main, all in code unrelated to this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now prints a startup boot summary to stderr showing version, target command (truncated) and active overlays; summary output is safe against write failures and exposed via the public API.

* **Tests**
  * Added unit and integration tests for rendering, truncation, formatting, env-based silencing, and CLI emission.

* **Documentation**
  * Help/docs updated to document environment variables to suppress the summary; policy doc expanded for audit findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->