### PR TITLE
fix(lenses): five new cloud lenses + transparency-rule polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 JanuScope **hides the dangerous tools**, **scrubs PII** out of returned values before the model reads them, **logs every call**, and **pre-injects your DB schema** so the model doesn't waste five calls discovering it. **Runs locally, no hosted gateway in the data path.**
 
-One YAML (called a **Lens**) wraps any MCP server with **security guardrails, schema injection**, and **full audit logging**. There are **[15 bundled Lenses](#option-a-use-a-bundled-lens-fastest-drop-in)** covering **databases (Postgres, MySQL, MongoDB, ClickHouse, Redis, SQLite, Microsoft SQL Server / Azure SQL, Oracle, Supabase), SaaS APIs (Stripe, Notion, Atlassian, Linear), source control (GitHub), and the filesystem**. A **community ecosystem of _per-MCP_ Lenses** (YAML config files), and measured **benchmarks** showing **84% fewer tokens** and **~3× faster responses** across a multi-question session on Postgres (median of 4 runs). **Zero server changes. No hosted gateway in the data path.** Works with **Claude Code, VSCode Copilot, Codex, Cursor,** and any MCP client.
+One YAML (called a **Lens**) wraps any MCP server with **security guardrails, schema injection**, and **full audit logging**. There are **[20 bundled Lenses](#option-a-use-a-bundled-lens-fastest-drop-in)** covering **databases (Postgres, MySQL, MongoDB, ClickHouse, Redis, SQLite, Microsoft SQL Server / Azure SQL, Oracle, Neon, Snowflake, Aurora DSQL, Redshift, Supabase self-host), SaaS APIs (Stripe, Notion, Atlassian, Linear, Supabase Cloud), source control (GitHub), and the filesystem**. A **community ecosystem of _per-MCP_ Lenses** (YAML config files), and measured **benchmarks** showing **84% fewer tokens** and **~3× faster responses** across a multi-question session on Postgres (median of 4 runs). **Zero server changes. No hosted gateway in the data path.** Works with **Claude Code, VSCode Copilot, Codex, Cursor,** and any MCP client.
 
 > 🧠 **Need codebase understanding together with MCP governance?** See our sibling project [**SocratiCode**](https://github.com/giancarloerra/socraticode): local-first codebase intelligence with semantic search, dependency graphs, symbol-level impact analysis.
 
@@ -377,6 +377,190 @@ The wrap pattern is the same across every host (Claude Desktop, Cursor, Claude C
 </tr>
 
 <tr>
+<td>Supabase (cloud)</td>
+<td><a href="https://github.com/supabase-community/supabase-mcp">Supabase hosted MCP (mcp.supabase.com)</a></td>
+<td>
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "mcp-remote",
+    "https://mcp.supabase.com/mcp?read_only=true",
+    "--header",
+    "Authorization:Bearer YOUR_SBP_TOKEN",
+    "--transport",
+    "http-only"
+  ]
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "januscope", "--config", "supabase-cloud"],
+  "env": {
+    "SUPABASE_ACCESS_TOKEN": "sbp_your_token_here"
+  }
+}
+```
+
+</td>
+</tr>
+
+<tr>
+<td>Snowflake</td>
+<td><a href="https://github.com/Snowflake-Labs/mcp">Snowflake-Labs/mcp</a> (uvx)</td>
+<td>
+
+```json
+{
+  "command": "uvx",
+  "args": ["snowflake-labs-mcp", "--service-config-file", "/path/to/services.yaml"],
+  "env": {
+    "SNOWFLAKE_ACCOUNT": "ORG-ACCOUNT",
+    "SNOWFLAKE_USER": "your_user",
+    "SNOWFLAKE_PASSWORD": "<your_PAT>",
+    "SNOWFLAKE_ROLE": "ACCOUNTADMIN",
+    "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH"
+  }
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "januscope", "--config", "snowflake-labs"],
+  "env": {
+    "SNOWFLAKE_ACCOUNT": "ORG-ACCOUNT",
+    "SNOWFLAKE_USER": "your_user",
+    "SNOWFLAKE_PASSWORD": "<your_PAT>",
+    "SNOWFLAKE_ROLE": "ACCOUNTADMIN",
+    "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
+    "SNOWFLAKE_MCP_CONFIG": "/path/to/services.yaml"
+  }
+}
+```
+
+</td>
+</tr>
+
+<tr>
+<td>AWS Aurora DSQL</td>
+<td><a href="https://github.com/awslabs/mcp/tree/main/src/aurora-dsql-mcp-server">awslabs.aurora-dsql-mcp-server</a> (uvx)</td>
+<td>
+
+```json
+{
+  "command": "uvx",
+  "args": [
+    "awslabs.aurora-dsql-mcp-server@latest",
+    "--cluster_endpoint",
+    "<id>.dsql.eu-west-2.on.aws",
+    "--region",
+    "eu-west-2",
+    "--database_user",
+    "admin"
+  ]
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "januscope", "--config", "aurora-dsql"],
+  "env": {
+    "DSQL_CLUSTER_ENDPOINT": "<id>.dsql.eu-west-2.on.aws",
+    "AWS_REGION": "eu-west-2",
+    "DSQL_DATABASE_USER": "admin",
+    "AWS_PROFILE": "default"
+  }
+}
+```
+
+</td>
+</tr>
+
+<tr>
+<td>AWS Redshift</td>
+<td><a href="https://github.com/awslabs/mcp/tree/main/src/redshift-mcp-server">awslabs.redshift-mcp-server</a> (uvx)</td>
+<td>
+
+```json
+{
+  "command": "uvx",
+  "args": ["awslabs.redshift-mcp-server@latest"],
+  "env": {
+    "AWS_REGION": "eu-west-2",
+    "AWS_PROFILE": "default"
+  }
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "januscope", "--config", "redshift"],
+  "env": {
+    "AWS_REGION": "eu-west-2",
+    "AWS_PROFILE": "default"
+  }
+}
+```
+
+</td>
+</tr>
+
+<tr>
+<td>Neon (hosted Postgres)</td>
+<td><a href="https://github.com/neondatabase/mcp-server-neon">Neon hosted MCP (mcp.neon.tech)</a></td>
+<td>
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "mcp-remote",
+    "https://mcp.neon.tech/mcp?readonly=true",
+    "--header",
+    "Authorization:Bearer YOUR_NAPI_TOKEN",
+    "--transport",
+    "http-only"
+  ]
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "januscope", "--config", "neon-cloud"],
+  "env": {
+    "NEON_API_KEY": "napi_your_token_here"
+  }
+}
+```
+
+</td>
+</tr>
+
+<tr>
 <td>Filesystem</td>
 <td><a href="https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem">modelcontextprotocol/server-filesystem</a></td>
 <td>
@@ -553,7 +737,9 @@ The wrap pattern is the same across every host (Claude Desktop, Cursor, Claude C
 
 > **Your favourite service / MCP isn't here?** [Open a lens-request issue](https://github.com/giancarloerra/januscope/issues/new?template=lens_request.yml) so a maintainer or community contributor can pick it up. Or [contribute one yourself](./lenses/CONTRIBUTING.md): it's a single YAML file plus a short README.
 >
-> **About the env block.** For most lenses the env block is byte-identical to what your vanilla setup had: JanuScope passes inherited env vars through unchanged. Three exceptions where the connection info moves from a positional argument into an env var (because the upstream MCP takes it as `argv`, and JanuScope's lens-spawning needs to read it from somewhere): **Redis** (`REDIS_URL`), **SQLite** (`SQLITE_DB_PATH`), **Filesystem** (`FILESYSTEM_ALLOWED_DIR`). The right-hand columns above show this for those three.
+> **About the env block.** For most lenses the env block is byte-identical to what your vanilla setup had: JanuScope passes inherited env vars through unchanged. Two exceptions where the connection info moves from a positional argument into an env var (because the upstream MCP takes the value as `argv`, and JanuScope's lens-spawning needs to read it from somewhere): **SQLite** (`SQLITE_DB_PATH`), **Filesystem** (`FILESYSTEM_ALLOWED_DIR`). The right-hand columns above show this for those two.
+>
+> **Most lenses run via `npx`/`uvx` and need only Node.js 20+.** Three lenses wrap CLIs that need a one-time local install: `dab` for `mssql-azure-dab` (`dotnet tool install -g Microsoft.DataApiBuilder`), `sql` for `oracle-db-sqlcl` ([Oracle SQLcl 25.4+ download](https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/download/)), and `docker` for `github-official`. Each per-lens README links the install step.
 >
 > **Quick browse.** `npx januscope lenses list` lists every bundled lens; `npx januscope lenses show <name>` prints its full config + README.
 
@@ -633,14 +819,14 @@ Same six-overlay pattern applies to non-database MCPs, drop `dbSchema` and `sqlG
 
 Fair question, and the bundled Postgres lens does exactly that, as a baseline. JanuScope sits _on top of_ whatever read-only mode your MCP offers, because a single MCP-level flag only solves one of the three problems above:
 
-| What `--access-mode=restricted` gives you | What JanuScope adds on top                                                                                                                                                |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Postgres blocks DML at the DB layer       | `audit`, every call as JSONL with SHA-256 args hash; compliance-ready without changing the MCP                                                                            |
-| (that's it)                               | `redact`, PII scrubbed before the LLM ever sees it, with field-path rules that reach into JSON-in-text envelopes                                                          |
-| (that's it)                               | `instructions`, policy text pushed into every tool description; reduces the social-engineering leak rate we measure in the benchmark                                      |
-| (that's it)                               | `dbSchema` pre-injection, 84% token reduction, cached across the session                                                                                                  |
-| (that's it)                               | `sqlGuard`, a proxy-layer backstop against bypasses the DB-level role can't catch (UDF-name fragments like `SELECT dropUsers()`, see below)                               |
-| Postgres only                             | Same six overlays apply to the other 14 bundled lenses (MongoDB, MS SQL via DAB, Oracle SQLcl, Supabase, Redis, Stripe, GitHub, filesystem, Notion, Atlassian, Linear, …) |
+| What `--access-mode=restricted` gives you | What JanuScope adds on top                                                                                                                                                                                                                                                        |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Postgres blocks DML at the DB layer       | `audit`, every call as JSONL with SHA-256 args hash; compliance-ready without changing the MCP                                                                                                                                                                                    |
+| (that's it)                               | `redact`, PII scrubbed before the LLM ever sees it, with field-path rules that reach into JSON-in-text envelopes                                                                                                                                                                  |
+| (that's it)                               | `instructions`, policy text pushed into every tool description; reduces the social-engineering leak rate we measure in the benchmark                                                                                                                                              |
+| (that's it)                               | `dbSchema` pre-injection, 84% token reduction, cached across the session                                                                                                                                                                                                          |
+| (that's it)                               | `sqlGuard`, a proxy-layer backstop against bypasses the DB-level role can't catch (UDF-name fragments like `SELECT dropUsers()`, see below)                                                                                                                                       |
+| Postgres only                             | The same six overlays apply to all 20 bundled lenses (Postgres, MongoDB, MS SQL via DAB, Oracle SQLcl, Snowflake, Aurora DSQL, Redshift, Supabase self-host, Supabase cloud, Neon cloud, MySQL, Redis, ClickHouse, SQLite, Stripe, GitHub, filesystem, Notion, Atlassian, Linear) |
 
 If you only need "don't write," a DB role or `--access-mode=restricted` is enough. If you also need audit, redaction, policy-in-description, schema injection, _and_ the same mental model across any MCPs, that's JanuScope.
 
@@ -709,7 +895,7 @@ januscope lenses list                       # show every bundled lens
 januscope lenses show mongodb-official      # print its config + README
 ```
 
-### Bundled Lenses (15)
+### Bundled Lenses (20)
 
 One Lens per service, pointing at the official vendor MCP where one exists. Community alternatives are included only for technologies without a single vendor (Postgres, MySQL, SQLite). Every Lens is verified against a live `tools/list` on its target MCP.
 
@@ -724,6 +910,10 @@ One Lens per service, pointing at the official vendor MCP where one exists. Comm
 - [`mssql-azure-dab`](./lenses/databases/mssql-azure-dab/): [Data API builder v1.7+ MCP](https://github.com/Azure/data-api-builder) for Azure SQL / SQL Server / SQLDW / Cosmos DB / PostgreSQL / MySQL. Blocks every write-shaped DML tool (`create_record`, `update_record`, `delete_record`, `execute_entity`); PII redaction; audit.
 - [`oracle-db-sqlcl`](./lenses/databases/oracle-db-sqlcl/): [Oracle SQLcl 25.4+ built-in MCP](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/26.1/sqcug/using-oracle-sqlcl-mcp-server.html). Blocks `run-sqlcl` (SQLcl meta-commands incl HOST shell escape); sqlGuard on `run-sql` for keyword-level write rejection; PII redaction; audit.
 - [`supabase-selfhost`](./lenses/databases/supabase-selfhost/): [Supabase self-host MCP](https://github.com/supabase-community/supabase-mcp) via `mcp-remote` against the local CLI stack at `http://127.0.0.1:54321/mcp`. Blocks `apply_migration`; sqlGuard on `execute_sql`; PII redaction including JWT-shaped tokens; audit.
+- [`neon-cloud`](./lenses/databases/neon-cloud/): [Neon hosted MCP](https://github.com/neondatabase/mcp-server-neon) via `mcp-remote` with API-key auth and server-side `?readonly=true`. Blocks `get_connection_string` (DSN credential leak); sqlGuard on `run_sql` and `run_sql_transaction`; PII redaction including DSN-shaped values; audit.
+- [`snowflake-labs`](./lenses/databases/snowflake-labs/): [Snowflake-Labs/mcp](https://github.com/Snowflake-Labs/mcp) via `uvx` with PAT auth. Blocks the generic DDL writers `create_object` / `drop_object` / `create_or_alter_object` (plus defensive globs); sqlGuard on `run_snowflake_query`; PII redaction including PAT/JWT-shaped tokens; audit. Includes a `services.example.yaml` for the MCP's required `--service-config-file`.
+- [`aurora-dsql`](./lenses/databases/aurora-dsql/): [awslabs.aurora-dsql-mcp-server](https://github.com/awslabs/mcp/tree/main/src/aurora-dsql-mcp-server) via `uvx` with AWS IAM auth. MCP runs in default read-only mode (no `--allow-writes`); sqlGuard layered on `readonly_query`; PII redaction including DSN-shaped values; audit.
+- [`redshift`](./lenses/databases/redshift/): [awslabs.redshift-mcp-server](https://github.com/awslabs/mcp/tree/main/src/redshift-mcp-server) via `uvx` with AWS IAM auth. Discovers both provisioned clusters and Serverless workgroups; sqlGuard on `execute_query`; PII redaction including JDBC Redshift / Postgres DSN shapes; audit. README includes the minimum IAM policy.
 
 **🔧 Developer tools**
 
@@ -736,6 +926,7 @@ One Lens per service, pointing at the official vendor MCP where one exists. Comm
 - [`notion-official`](./lenses/saas/notion-official/): [Notion's official hosted MCP](https://developers.notion.com/guides/mcp/get-started-with-mcp) via `mcp-remote`.
 - [`atlassian-official`](./lenses/saas/atlassian-official/): [Atlassian's official Rovo MCP](https://github.com/atlassian/atlassian-mcp-server) via `mcp-remote`. Jira, Confluence, Compass.
 - [`linear-remote`](./lenses/saas/linear-remote/): [Linear's official remote MCP](https://linear.app/docs/mcp) via `mcp-remote`.
+- [`supabase-cloud`](./lenses/saas/supabase-cloud/): [Supabase hosted MCP](https://github.com/supabase-community/supabase-mcp) at `mcp.supabase.com` via `mcp-remote` with PAT auth. Blocks every project / branch / migration / edge-function write (10 tools + defensive globs); sqlGuard on `execute_sql`; PII redaction including DSN and JWT shapes; audit. For the local-development MCP see `supabase-selfhost`.
 
 ### Contributing a lens
 

--- a/lenses/CONTRIBUTING.md
+++ b/lenses/CONTRIBUTING.md
@@ -119,11 +119,13 @@ Both patterns live entirely in the `instructions` field, which is **deliberately
 
 A maintainer will review (see [First-PR review policy](#first-pr-review-policy) below for newcomers).
 
-## Lens transparency rule (read this before writing `target.env`)
+## Lens transparency rule (read before touching env vars or `target.args`)
 
-A lens must be **as transparent as possible** about how the wrapped MCP is configured. Concretely, that means:
+A lens must be **as transparent as possible** about how the wrapped MCP is configured. The rule applies to `target.env`, to `${VAR}` substitutions inside `target.args`, and to whatever names the lens README tells the user to set. Concretely:
 
-**Operator-supplied env vars are never renamed by the lens.** The user sets the same env-var names that the upstream MCP itself reads. If the upstream wants `DATABASE_URI`, the user sets `DATABASE_URI`. The lens does not "translate" `${DATABASE_URL}` → `DATABASE_URI` even when one feels more conventional than the other. Renaming creates surprise: the user copies their existing MCP-client config, JanuScope silently expects different names, and either nothing connects or (worse) the lens substitution overwrites the user's working env var with empty string.
+**Operator-supplied env vars are never renamed by the lens.** The user sets the same env-var names that the upstream MCP itself reads. If the upstream wants `DATABASE_URI`, the user sets `DATABASE_URI`. The lens does not "translate" `${DATABASE_URL}` → `DATABASE_URI` even when one feels more conventional. This applies whether the rename happens via `target.env: { DATABASE_URI: "${DATABASE_URL}" }` (re-declaration) OR via `${DATABASE_URL}` in `target.args` (substitution-time rename). Renaming creates surprise: the user copies their existing MCP-client config, JanuScope silently expects different names, and either nothing connects or (worse) the lens substitution overwrites the user's working env var with empty string.
+
+**`${VAR}` substitutions in `target.args` follow the same rule.** When you reference `${SOME_NAME}` inside `target.args`, `SOME_NAME` should be the upstream tool's documented env-var name. If the upstream MCP itself accepts the value via env (e.g. `SNOWFLAKE_PASSWORD`, `DATABASE_URI`, `MYSQL_HOST`), prefer letting it flow through env propagation and skip the substitution entirely. Use a `${VAR}` substitution only when the upstream tool requires a CLI argument with no env-var equivalent — and even then, the variable name should match the upstream's published convention. **For remote HTTP MCPs** that authenticate via headers rather than env vars, follow the upstream ecosystem's standard env-var name (e.g. Supabase ecosystem uses `SUPABASE_ACCESS_TOKEN`, not a fresh `SUPABASE_PAT`).
 
 **Operator-supplied env vars are not re-declared in `target.env`.** For direct child-process targets, whatever the user sets in their MCP-client config's `"env"` block is inherited by JanuScope and then by the spawned target through `child_process.spawn` env merging. A lens that writes `target.env: { FOO: "${FOO}" }` is at best redundant and at worst breaks the inherited value when the substitution source isn't set. **Containerised targets are the exception**: if the lens runs `docker` or `podman`, the spawned `docker` process inherits the env, but the container it creates does NOT. You still need explicit `-e VAR` passthrough flags inside `target.args` to move selected env vars into the container. See `lenses/dev-tools/github-official/config.yaml` for the canonical pattern (`-e GITHUB_PERSONAL_ACCESS_TOKEN`, no `=`, which tells docker to forward the var from the calling environment).
 
@@ -134,6 +136,8 @@ A lens must be **as transparent as possible** about how the wrapped MCP is confi
 If your lens has no policy-value env hardcodes, omit the `target.env` block entirely.
 
 > **Worked example — Postgres.** `crystaldba/postgres-mcp` reads `DATABASE_URI`. The bundled `postgres-crystaldba` lens does **not** set `target.env: { DATABASE_URI: "${DATABASE_URL}" }` — that would be a rename. The lens's `target.env` is omitted; the user sets `DATABASE_URI` in their client config and it inherits through.
+
+> **Worked example — Supabase Cloud.** Supabase's hosted MCP at `mcp.supabase.com/mcp` authenticates via an `Authorization: Bearer <token>` header rather than reading an env var. The Supabase ecosystem's standard env-var name for that token is `SUPABASE_ACCESS_TOKEN` (used by the Supabase CLI and management-API docs), so the lens uses `${SUPABASE_ACCESS_TOKEN}` in its `target.args` `--header` flag — not a freshly invented `SUPABASE_PAT`. The user sets `SUPABASE_ACCESS_TOKEN` exactly the way they would for any other Supabase tool.
 
 ## File structure
 

--- a/lenses/databases/aurora-dsql/README.md
+++ b/lenses/databases/aurora-dsql/README.md
@@ -1,0 +1,145 @@
+---
+mcp: "awslabs.aurora-dsql-mcp-server"
+mcpUrl: https://github.com/awslabs/mcp/tree/main/src/aurora-dsql-mcp-server
+testedVersion: "awslabs-aurora-dsql-mcp-server 1.27.0"
+testedAt: "2026-05-06"
+maintainer: "@giancarloerra"
+category: databases
+status: probed
+tags: [aws, aurora-dsql, postgres-compatible, iam-auth, readonly]
+---
+
+# AWS Aurora DSQL — JanuScope Lens
+
+Wraps the [`awslabs.aurora-dsql-mcp-server`](https://github.com/awslabs/mcp/tree/main/src/aurora-dsql-mcp-server)
+which speaks stdio. Aurora DSQL is AWS's distributed Postgres-compatible
+serverless SQL service. The MCP authenticates via AWS IAM (no DSQL
+password — IAM-issued tokens) and uses the AWS SDK credential chain.
+
+This lens stays read-only by:
+
+1. Spawning the MCP **without `--allow-writes`** (the MCP defaults to
+   read-only and rejects mutations at execution time when this flag
+   is absent).
+2. Layering `sqlGuard` on `readonly_query` so any write keyword in
+   the SQL string is refused at the proxy before the MCP even sees
+   it.
+3. Redacting PII + DSN-shaped values in result frames.
+4. Auditing every tool call to `~/mcp-audit-aurora-dsql.jsonl`.
+
+## What this lens does
+
+- **`sqlGuard`** — `readonly_query`, `sqlArg: sql`, `readOnly: true`.
+- **`instructions`** — read-only banner, plus an explicit "do not
+  request `--allow-writes`" caution for the LLM.
+- **`redact`** — field-path PII rules + DSN / SSN / PAN / JWT
+  regex fallbacks.
+- **`audit`** — JSONL compliance log.
+
+No `block`: the MCP only surfaces 6 tools and none are write-shaped
+when the MCP is started without `--allow-writes`. The
+`transact` tool is left available because in read-only mode it is
+the canonical way to run multiple SELECTs at a consistent
+point-in-time snapshot; sqlGuard doesn't apply to its array-shaped
+`sql_list` argument, but the MCP rejects mutations in `transact`
+itself when `--allow-writes` is absent.
+
+## Tool names this lens assumes
+
+Probed against `awslabs-aurora-dsql-mcp-server` 1.27.0 on
+2026-05-06 with the MCP started in default (read-only) mode:
+
+| Tool                        | Kind               | Treatment                      |
+| --------------------------- | ------------------ | ------------------------------ |
+| `readonly_query`            | arbitrary SQL      | **sqlGuard ed**                |
+| `transact`                  | array of SQL stmts | passes through (MCP read-only) |
+| `get_schema`                | read (metadata)    | passes through                 |
+| `dsql_search_documentation` | read (docs KB)     | passes through                 |
+| `dsql_read_documentation`   | read (docs KB)     | passes through                 |
+| `dsql_recommend`            | read (advice)      | passes through                 |
+
+## Prerequisites
+
+1. **An Aurora DSQL cluster** in your AWS account
+   ([console](https://console.aws.amazon.com/dsql/)). The free trial
+   covers a small cluster.
+2. **`uv` / `uvx`** installed locally:
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+3. **AWS credentials** that the SDK can pick up — env vars, an
+   `~/.aws/credentials` profile, or any other source the AWS SDK's
+   default credential chain supports. The IAM principal needs
+   `dsql:DbConnect` (token issuance) plus the database-side role
+   you want the LLM to inherit.
+4. **A DSQL database role** scoped to read-only. DSQL roles are
+   bound to IAM principals — the README in the awslabs repo's
+   [`getting-started`](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
+   guide walks through creating one. Use that role's name as
+   `DSQL_DATABASE_USER`.
+
+## Customising
+
+The lens reads the cluster + region + database user from
+environment variables. JanuScope substitutes them into `target.args`
+at startup (no rename, the MCP's `--cluster_endpoint` / `--region` /
+`--database_user` CLI flags receive the values directly).
+
+| Variable                | Purpose                                                                                        |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `DSQL_CLUSTER_ENDPOINT` | e.g. `<id>.dsql.eu-west-2.on.aws`                                                              |
+| `AWS_REGION`            | AWS region of the cluster (e.g. `eu-west-2`)                                                   |
+| `DSQL_DATABASE_USER`    | DSQL role to assume (typically a read-only role)                                               |
+| AWS SDK credential vars | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`, or any other supported source |
+
+## Usage
+
+```json
+{
+  "mcpServers": {
+    "aurora-dsql": {
+      "command": "npx",
+      "args": ["-y", "januscope", "--config", "aurora-dsql"],
+      "env": {
+        "DSQL_CLUSTER_ENDPOINT": "<id>.dsql.eu-west-2.on.aws",
+        "AWS_REGION": "eu-west-2",
+        "DSQL_DATABASE_USER": "readonly_role",
+        "AWS_PROFILE": "default"
+      }
+    }
+  }
+}
+```
+
+`AWS_PROFILE` reads `~/.aws/credentials`; alternatively pass
+`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` directly in the
+`env` block. JanuScope inherits whatever the AWS SDK reads.
+
+## Probe transcript (2026-05-06)
+
+A live `tools/list` against `uvx awslabs.aurora-dsql-mcp-server@latest`
+returned the six tools shown in the table above. Server identity:
+`{"name": "awslabs-aurora-dsql-mcp-server", "version": "1.27.0"}`. The
+probe was driven against an Aurora DSQL cluster in `eu-west-2`, with
+the MCP starting in default (read-only) mode (no `--allow-writes`
+flag).
+
+Server-side log: `Aurora DSQL MCP init with CLUSTER_ENDPOINT:…,
+REGION: eu-west-2, DATABASE_USER:admin, MODE:READ-ONLY,
+AWS_PROFILE:default, KNOWLEDGE_SERVER:…`. The `MODE:READ-ONLY` line
+is the upstream MCP's own confirmation of its posture.
+
+## Three-layer recap
+
+JanuScope's lens is layer 1 (proxy block + sqlGuard). The MCP's
+read-only mode is layer 2 (default behaviour without `--allow-writes`).
+A scoped DSQL database role bound to a least-privilege IAM principal
+is layer 3 (the data-path enforcement that survives even if
+layers 1 + 2 misconfigure). Production deployments should rely on
+layer 3 as the source of truth.
+
+## Changelog
+
+- **2026-05-06** — Initial contribution (@giancarloerra). Probed
+  against awslabs-aurora-dsql-mcp-server 1.27.0 in `eu-west-2` with
+  IAM-based auth.

--- a/lenses/databases/aurora-dsql/config.yaml
+++ b/lenses/databases/aurora-dsql/config.yaml
@@ -1,0 +1,82 @@
+# AWS Aurora DSQL — JanuScope Lens
+#
+# Wraps awslabs.aurora-dsql-mcp-server (uvx). The MCP itself is
+# read-only by default (without `--allow-writes`); this lens
+# enforces that posture at the proxy layer too as defence in depth,
+# and adds sqlGuard on the single-string SQL tool plus PII redaction
+# and audit.
+#
+# Tools observed in live tools/list (awslabs-aurora-dsql-mcp-server
+# 1.27.0, READ-ONLY mode, 2026-05-06):
+#   ARBITRARY-SQL: readonly_query (sql string)        → sqlGuard
+#   ARBITRARY-SQL: transact      (sql_list array)     → MCP-side
+#                                                       read-only
+#                                                       enforcement
+#                                                       (no
+#                                                       --allow-writes)
+#   READ : get_schema, dsql_search_documentation,
+#          dsql_read_documentation, dsql_recommend
+
+target:
+  command: uvx
+  args:
+    - "awslabs.aurora-dsql-mcp-server@latest"
+    - "--cluster_endpoint"
+    - "${DSQL_CLUSTER_ENDPOINT}"
+    - "--region"
+    - "${AWS_REGION}"
+    - "--database_user"
+    - "${DSQL_DATABASE_USER}"
+    # IMPORTANT: do NOT add --allow-writes. The MCP defaults to
+    # read-only and this lens depends on that default to stay safe.
+
+# firstRun: approve
+
+# `readonly_query` accepts arbitrary SQL through the `sql` argument.
+# Even though the MCP enforces read-only at execution time, layer
+# keyword-level write rejection at the proxy. Defence in depth.
+sqlGuard:
+  tools:
+    - readonly_query
+  sqlArg: sql
+  readOnly: true
+
+instructions: |
+  READ-ONLY Aurora DSQL. The proxy wraps the MCP in its default
+  read-only mode (`--allow-writes` is intentionally NOT passed).
+  - `readonly_query` for SELECT / WITH queries; sqlGuard rejects
+    any statement containing INSERT / UPDATE / DELETE / DROP /
+    CREATE / ALTER / TRUNCATE / GRANT / etc.
+  - `transact` for multi-statement read transactions when you need
+    point-in-time consistency across several SELECTs; the MCP
+    rejects mutations in read-only mode.
+  - `get_schema <table>` to inspect schema before querying.
+  - `dsql_search_documentation` / `dsql_read_documentation` /
+    `dsql_recommend` for DSQL reference and best-practice guidance.
+  Do not request --allow-writes; the deployment posture is read-only
+  by design and any write attempt is refused at multiple layers.
+
+redact:
+  rules:
+    # PII field paths in JSON tool results (DSQL is Postgres-
+    # compatible so identifier folding is the same).
+    - field: "**.email"
+    - field: "**.password"
+    - field: "**.password_hash"
+    - field: "**.api_key"
+    - field: "**.apiKey"
+    - field: "**.token"
+    - field: "**.secret"
+    # Connection-string-shaped values that may appear in error
+    # messages or schema introspection output.
+    - regex: "\\bpostgres(ql)?://[^\\s]*?:[^\\s@]+@[^\\s/]+"
+    # Value-shape fallbacks.
+    - regex: '\b\d{3}-\d{2}-\d{4}\b' # US SSN
+    - regex: '\b(?:\d[ -]*?){13,16}\b' # PAN-shaped digit run
+    - regex: '\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b' # JWT
+  replacement: "[REDACTED]"
+  applyTo: text
+
+audit:
+  sink: "~/mcp-audit-aurora-dsql.jsonl"
+  logRawArgs: false

--- a/lenses/databases/neon-cloud/README.md
+++ b/lenses/databases/neon-cloud/README.md
@@ -1,0 +1,137 @@
+---
+mcp: "Neon hosted MCP (mcp-server-neon)"
+mcpUrl: https://github.com/neondatabase/mcp-server-neon
+testedVersion: "mcp-server-neon 1.0.0 (hosted at mcp.neon.tech)"
+testedAt: "2026-05-06"
+maintainer: "@giancarloerra"
+category: databases
+status: probed
+tags: [neon, postgres, hosted, mcp-remote, readonly]
+---
+
+# Neon (hosted Postgres) — JanuScope Lens
+
+Wraps Neon's hosted MCP server at `https://mcp.neon.tech/mcp` via
+[`mcp-remote`](https://github.com/geelen/mcp-remote). Neon is a hosted
+Postgres-as-a-service whose MCP exposes project / branch management,
+schema introspection, and read-only SQL execution.
+
+This lens locks the surface to read-only by:
+
+1. Setting Neon's server-side **`?readonly=true`** flag on the URL
+   (Neon's own readonly enforcement at the data layer).
+2. **Blocking `get_connection_string`** at the proxy. That tool
+   returns the raw Postgres DSN (with username + password) and is a
+   credential leak to the LLM regardless of read-only mode.
+3. **`sqlGuard`-ing `run_sql` and `run_sql_transaction`** to reject
+   any SQL containing a write keyword (defence in depth on top of
+   the server-side readonly).
+4. **Redacting PII + connection-string-shaped values** in result
+   frames.
+5. **Auditing** every tool call to `~/mcp-audit-neon.jsonl`.
+
+## What this lens does
+
+- **`block`** — `get_connection_string` (DSN credential leak).
+- **`sqlGuard`** — `run_sql`, `run_sql_transaction`, `sqlArg: sql`,
+  `readOnly: true`.
+- **`instructions`** — read-only banner with the canonical tool path.
+- **`redact`** — field-path PII rules + regex fallbacks for DSN
+  patterns, SSN, PAN, JWT.
+- **`audit`** — JSONL compliance log at `~/mcp-audit-neon.jsonl`.
+
+The lens uses `mcp-remote` to bridge the HTTP MCP into stdio (Neon
+ships streamable-HTTP, JanuScope's engine is stdio-native). API-key
+auth is passed via the `Authorization: Bearer <key>` header.
+
+## Tool names this lens assumes
+
+Probed against `mcp-server-neon` 1.0.0 hosted at `mcp.neon.tech` on
+2026-05-06 with `?readonly=true`:
+
+| Tool                      | Kind             | Treatment       |
+| ------------------------- | ---------------- | --------------- |
+| `list_projects`           | read             | passes through  |
+| `list_organizations`      | read             | passes through  |
+| `list_shared_projects`    | read             | passes through  |
+| `describe_project`        | read             | passes through  |
+| `describe_branch`         | read             | passes through  |
+| `describe_table_schema`   | read (metadata)  | passes through  |
+| `get_database_tables`     | read (metadata)  | passes through  |
+| `list_branch_computes`    | read             | passes through  |
+| `list_slow_queries`       | read (analytics) | passes through  |
+| `compare_database_schema` | read (analytics) | passes through  |
+| `explain_sql_statement`   | read (analysis)  | passes through  |
+| `search`                  | read (docs KB)   | passes through  |
+| `fetch`                   | read (docs KB)   | passes through  |
+| `list_docs_resources`     | read (docs KB)   | passes through  |
+| `get_doc_resource`        | read (docs KB)   | passes through  |
+| `run_sql`                 | arbitrary SQL    | **sqlGuard ed** |
+| `run_sql_transaction`     | arbitrary SQL    | **sqlGuard ed** |
+| `get_connection_string`   | DSN leak         | **blocked**     |
+
+## Prerequisites
+
+1. **A Neon account** ([console.neon.tech/signup](https://console.neon.tech/signup)).
+   The free tier is permanent and sufficient for this lens.
+2. **A Neon API key**. In the Neon console, navigate to **Account
+   settings → API keys → Create API key**, copy the value (only shown
+   once). The key starts with `napi_`.
+3. **Node.js 20+** for `mcp-remote` (fetched by `npx -y` on first use).
+
+## Customising
+
+The lens reads the Neon API key from the `NEON_API_KEY` environment
+variable, which is the natural place for the user to set it (in their
+MCP-client config's `env` block, in their shell, or via a secret-vault
+reference like `${vault://secrets/neon#api_key}` if they use one).
+JanuScope substitutes `${NEON_API_KEY}` in `target.args` at startup.
+
+If you want to scope the MCP to a single project (recommended for
+safety in production), add `&projectId=<your-project-id>` to the URL
+in `target.args`. The Neon docs list other URL params (`category=`,
+etc.) for further narrowing.
+
+## Usage
+
+```json
+{
+  "mcpServers": {
+    "neon": {
+      "command": "npx",
+      "args": ["-y", "januscope", "--config", "neon-cloud"],
+      "env": {
+        "NEON_API_KEY": "napi_your_token_here"
+      }
+    }
+  }
+}
+```
+
+Replace `napi_your_token_here` with your Neon API key. The token
+inherits straight through to `mcp-remote`'s Authorization header
+without any rename.
+
+## Probe transcript (2026-05-06)
+
+A live `tools/list` against the bridged stdio session returned the
+eighteen tools shown in the table above. Server identity:
+`{"name": "mcp-server-neon", "version": "1.0.0"}`. The probe was driven
+against the live `mcp.neon.tech` endpoint with `?readonly=true` and
+API-key auth.
+
+## Note on OAuth vs API-key auth
+
+Neon's MCP supports both OAuth (browser flow) and API-key (header)
+auth. This lens uses API-key auth because it works in non-interactive
+contexts (CI, MCP-client configs without browser access) and because
+it lets the operator control the read/write scope at the API-key level.
+For interactive workflows, OAuth is also supported by `mcp-remote`,
+just remove `--header` from `target.args` and a browser tab will
+open on first launch.
+
+## Changelog
+
+- **2026-05-06** — Initial contribution (@giancarloerra). Probed
+  against `mcp-server-neon` 1.0.0 hosted at `mcp.neon.tech` with
+  API-key auth and `?readonly=true`.

--- a/lenses/databases/neon-cloud/config.yaml
+++ b/lenses/databases/neon-cloud/config.yaml
@@ -1,0 +1,92 @@
+# Neon (hosted Postgres) — JanuScope Lens
+#
+# Wraps Neon's hosted MCP server at https://mcp.neon.tech/mcp via
+# `mcp-remote` with API-key auth. The Neon MCP itself supports a
+# server-side `?readonly=true` flag which restricts the upstream tool
+# surface; this lens always sets that flag and additionally layers
+# proxy-side block / sqlGuard / redact / audit.
+#
+# Tools observed in live tools/list (mcp-server-neon 1.0.0,
+# readonly=true, 2026-05-06):
+#   READ : list_projects, list_organizations, list_shared_projects,
+#          describe_project, describe_branch, describe_table_schema,
+#          get_database_tables, list_branch_computes, list_slow_queries,
+#          compare_database_schema, search, fetch, list_docs_resources,
+#          get_doc_resource
+#   ARBITRARY-SQL: run_sql, run_sql_transaction (sqlGuard)
+#   CREDENTIAL-LEAK: get_connection_string (blocked — returns the
+#                    raw Postgres DSN incl password, which the LLM has
+#                    no business seeing)
+#   READ-ANALYSIS: explain_sql_statement (read-shaped)
+
+target:
+  command: npx
+  args:
+    - "-y"
+    - "mcp-remote"
+    - "https://mcp.neon.tech/mcp?readonly=true"
+    - "--header"
+    - "Authorization:Bearer ${NEON_API_KEY}"
+    - "--transport"
+    - "http-only"
+
+# firstRun: approve
+
+block:
+  # `get_connection_string` returns the live database DSN
+  # (postgresql://user:password@host/db). That's a credential leak
+  # to the LLM and should never be exposed regardless of read-only
+  # mode at the database level.
+  - get_connection_string
+
+# Both run_sql and run_sql_transaction execute caller-supplied SQL.
+# Neon's server-side readonly enforcement is layer 1; sqlGuard is
+# layer 2 (defence in depth, in case the readonly URL flag was
+# stripped or a future MCP version reinterprets it).
+sqlGuard:
+  tools:
+    - run_sql
+    - run_sql_transaction
+  sqlArg: sql
+  readOnly: true
+
+instructions: |
+  READ-ONLY Neon (hosted Postgres). This proxy wraps mcp.neon.tech
+  with the server-side `readonly=true` flag, plus proxy-layer
+  sqlGuard on run_sql / run_sql_transaction.
+  - Use `list_projects` / `describe_project` / `describe_branch` /
+    `get_database_tables` / `describe_table_schema` for orientation.
+  - Use `run_sql` for SELECT / WITH-prefixed queries; the proxy
+    rejects any statement containing INSERT / UPDATE / DELETE /
+    DROP / CREATE / ALTER / TRUNCATE / GRANT / etc.
+  - `get_connection_string` is BLOCKED. Do not request the database
+    DSN; the credentials inside it are not sanctioned for the LLM.
+  - `compare_database_schema` and `list_slow_queries` are useful
+    for migration planning and perf analysis without touching
+    production data.
+
+redact:
+  rules:
+    # PII field paths in JSON tool results (Neon returns rows as
+    # JSON objects from run_sql, table descriptions from describe_*).
+    - field: "**.email"
+    - field: "**.password"
+    - field: "**.password_hash"
+    - field: "**.api_key"
+    - field: "**.apiKey"
+    - field: "**.token"
+    - field: "**.secret"
+    # Connection-string-shaped values that might leak through error
+    # messages or other tool outputs even though get_connection_string
+    # is blocked. The pattern matches `postgres://...:...@...` shapes.
+    - regex: "\\bpostgres(ql)?://[^\\s]*?:[^\\s@]+@[^\\s/]+"
+    # Value-shape fallbacks for free-text columns and log lines.
+    - regex: '\b\d{3}-\d{2}-\d{4}\b' # US SSN
+    - regex: '\b(?:\d[ -]*?){13,16}\b' # PAN-shaped digit run
+    - regex: '\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b' # JWT
+  replacement: "[REDACTED]"
+  applyTo: text
+
+audit:
+  sink: "~/mcp-audit-neon.jsonl"
+  logRawArgs: false

--- a/lenses/databases/redis-official/config.yaml
+++ b/lenses/databases/redis-official/config.yaml
@@ -28,9 +28,12 @@ target:
     - "--from"
     - "redis-mcp-server@latest"
     - "redis-mcp-server"
-    - "--url"
-    - "${REDIS_URL}"
-  env: {}
+  # No env block and no `--url` CLI flag. `redis-mcp-server` reads
+  # `REDIS_URL` (and the discrete `REDIS_HOST` / `REDIS_PORT` /
+  # `REDIS_USERNAME` / `REDIS_PASSWORD` / `REDIS_SSL` family) directly
+  # from process env, so the user's MCP-client config env block
+  # inherits straight through. Lens transparency: never rename or
+  # relay operator-supplied env vars. See lenses/CONTRIBUTING.md.
 
 # Data-sensitivity label. Redis is a common home for session
 # tokens, JWTs, hot-cache PII, and rate-limit counters, so treat as

--- a/lenses/databases/redshift/README.md
+++ b/lenses/databases/redshift/README.md
@@ -1,0 +1,149 @@
+---
+mcp: "awslabs.redshift-mcp-server"
+mcpUrl: https://github.com/awslabs/mcp/tree/main/src/redshift-mcp-server
+testedVersion: "awslabs.redshift-mcp-server 1.27.0"
+testedAt: "2026-05-06"
+maintainer: "@giancarloerra"
+category: databases
+status: probed
+tags: [aws, redshift, redshift-serverless, iam-auth, readonly]
+---
+
+# AWS Redshift — JanuScope Lens
+
+Wraps the [`awslabs.redshift-mcp-server`](https://github.com/awslabs/mcp/tree/main/src/redshift-mcp-server)
+which speaks stdio. The MCP discovers both **provisioned Redshift
+clusters and Redshift Serverless workgroups** in the configured AWS
+account/region, exposes hierarchical schema introspection tools, and
+runs SQL through the [Redshift Data API](https://docs.aws.amazon.com/redshift-data/latest/APIReference/Welcome.html)
+in read-only mode.
+
+This lens stays read-only by:
+
+1. Relying on the MCP's **default read-only mode** (write support
+   is planned for a future MCP release; this lens does not enable
+   it).
+2. Layering `sqlGuard` on `execute_query` so any write keyword in
+   the SQL string is refused at the proxy before the MCP sees it.
+3. Redacting PII + DSN-shaped values in result frames.
+4. Auditing every tool call to `~/mcp-audit-redshift.jsonl`.
+
+## What this lens does
+
+- **`sqlGuard`** — `execute_query`, `sqlArg: sql`, `readOnly: true`.
+- **`instructions`** — read-only banner with the canonical
+  `list_clusters → list_databases → list_schemas → list_tables →
+list_columns → execute_query` discovery flow.
+- **`redact`** — field-path PII rules + DSN / SSN / PAN / JWT
+  regex fallbacks (Postgres, JDBC Redshift, JDBC Postgres URI
+  shapes).
+- **`audit`** — JSONL compliance log.
+
+No `block`: the MCP only surfaces 6 tools and 5 are pure read; the
+sixth (`execute_query`) gets sqlGuard.
+
+## Tool names this lens assumes
+
+Probed against `awslabs.redshift-mcp-server` 1.27.0 on 2026-05-06:
+
+| Tool             | Kind             | Treatment       |
+| ---------------- | ---------------- | --------------- |
+| `list_clusters`  | read (discovery) | passes through  |
+| `list_databases` | read (metadata)  | passes through  |
+| `list_schemas`   | read (metadata)  | passes through  |
+| `list_tables`    | read (metadata)  | passes through  |
+| `list_columns`   | read (metadata)  | passes through  |
+| `execute_query`  | arbitrary SQL    | **sqlGuard ed** |
+
+## Prerequisites
+
+1. **A Redshift cluster or Serverless workgroup** in your AWS
+   account.
+2. **`uv` / `uvx`** installed locally.
+3. **AWS credentials** the SDK can pick up (env vars, profile, etc.).
+4. **An IAM policy** attached to the principal the lens
+   authenticates as. The lens requires the following actions to
+   discover Redshift resources and execute queries through the
+   Redshift Data API:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "redshift:DescribeClusters",
+           "redshift-serverless:ListWorkgroups",
+           "redshift-serverless:GetWorkgroup",
+           "redshift-data:ListDatabases",
+           "redshift-data:ListSchemas",
+           "redshift-data:ListTables",
+           "redshift-data:DescribeTable",
+           "redshift-data:ExecuteStatement",
+           "redshift-data:DescribeStatement",
+           "redshift-data:GetStatementResult"
+         ],
+         "Resource": "*"
+       }
+     ]
+   }
+   ```
+
+   Attach this policy to `<your-iam-principal>` (the IAM user, role,
+   or federated identity whose credentials feed the AWS SDK chain
+   the lens reads). All ten actions are required; the discovery
+   chain (`list_clusters` → `list_databases` → `list_schemas` →
+   `list_tables` → `list_columns`) fails on the first missing
+   action.
+
+## Customising
+
+The lens reads AWS context from standard SDK env vars; JanuScope
+does not rename them.
+
+| Variable                                      | Purpose                                                    |
+| --------------------------------------------- | ---------------------------------------------------------- |
+| `AWS_REGION`                                  | AWS region of the Redshift cluster/workgroup               |
+| `AWS_PROFILE`                                 | (optional) named profile to read from `~/.aws/credentials` |
+| `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` | direct creds; alternative to `AWS_PROFILE`                 |
+
+## Usage
+
+```json
+{
+  "mcpServers": {
+    "redshift": {
+      "command": "npx",
+      "args": ["-y", "januscope", "--config", "redshift"],
+      "env": {
+        "AWS_REGION": "eu-west-2",
+        "AWS_PROFILE": "default"
+      }
+    }
+  }
+}
+```
+
+## Probe transcript (2026-05-06)
+
+A live `tools/list` against `uvx awslabs.redshift-mcp-server@latest`
+returned the six tools shown in the table above. Server identity:
+`{"name": "awslabs.redshift-mcp-server", "version": "1.27.0"}`. The
+probe was driven against an AWS account in `eu-west-2`; the MCP's
+own startup log confirms it ran a `ListToolsRequest` round-trip.
+
+## Three-layer recap
+
+JanuScope's lens is layer 1 (proxy `sqlGuard`). The MCP's read-only
+mode is layer 2 (current default behaviour). A scoped IAM principal
+with read-only Redshift Data API actions only is layer 3 (the
+data-path enforcement). Production deployments should lean on
+layer 3 — even if the MCP later adds a `--allow-writes` flag, an
+IAM principal without the corresponding `Update*`/`Delete*`
+actions cannot mutate.
+
+## Changelog
+
+- **2026-05-06** — Initial contribution (@giancarloerra). Probed
+  against awslabs.redshift-mcp-server 1.27.0 in `eu-west-2`.

--- a/lenses/databases/redshift/config.yaml
+++ b/lenses/databases/redshift/config.yaml
@@ -1,0 +1,68 @@
+# AWS Redshift — JanuScope Lens
+#
+# Wraps awslabs.redshift-mcp-server (uvx). The MCP itself runs in
+# READ-ONLY mode (per its own description; READ-WRITE support is
+# planned for a future release). The lens layers sqlGuard on top
+# as defence in depth, plus PII redaction and audit.
+#
+# Tools observed in live tools/list (awslabs.redshift-mcp-server
+# 1.27.0, 2026-05-06):
+#   READ : list_clusters, list_databases, list_schemas,
+#          list_tables, list_columns
+#   ARBITRARY-SQL: execute_query (sql string) → sqlGuard
+
+target:
+  command: uvx
+  args:
+    - "awslabs.redshift-mcp-server@latest"
+
+# firstRun: approve
+
+# `execute_query` accepts SQL through the `sql` argument. The MCP
+# is server-side read-only today, but layer keyword-level write
+# rejection at the proxy too (defence in depth, and forward-
+# compatible with the MCP's planned read-write mode — when that
+# ships, JanuScope still says no without the user reconfiguring).
+sqlGuard:
+  tools:
+    - execute_query
+  sqlArg: sql
+  readOnly: true
+
+instructions: |
+  READ-ONLY Redshift. The proxy wraps the AWS Labs Redshift MCP
+  which runs in read-only mode by default.
+  - `list_clusters` to discover Redshift provisioned clusters and
+    Serverless workgroups your IAM principal has access to.
+  - `list_databases` / `list_schemas` / `list_tables` /
+    `list_columns` for hierarchical schema discovery.
+  - `execute_query` for SELECT / WITH queries; the proxy rejects
+    any statement containing INSERT / UPDATE / DELETE / DROP /
+    CREATE / ALTER / TRUNCATE / GRANT / etc.
+  Operations against multiple clusters in one session are
+  supported by passing different `cluster_identifier` values to
+  the tools.
+
+redact:
+  rules:
+    # PII field paths in Redshift result rows.
+    - field: "**.email"
+    - field: "**.password"
+    - field: "**.password_hash"
+    - field: "**.api_key"
+    - field: "**.apiKey"
+    - field: "**.token"
+    - field: "**.secret"
+    # Connection-string-shaped values that may leak through error
+    # messages or schema introspection.
+    - regex: "\\b(postgres|jdbc:redshift|jdbc:postgresql)://[^\\s]*?:[^\\s@]+@[^\\s/]+"
+    # Value-shape fallbacks.
+    - regex: '\b\d{3}-\d{2}-\d{4}\b' # US SSN
+    - regex: '\b(?:\d[ -]*?){13,16}\b' # PAN-shaped digit run
+    - regex: '\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b' # JWT
+  replacement: "[REDACTED]"
+  applyTo: text
+
+audit:
+  sink: "~/mcp-audit-redshift.jsonl"
+  logRawArgs: false

--- a/lenses/databases/snowflake-labs/README.md
+++ b/lenses/databases/snowflake-labs/README.md
@@ -1,0 +1,182 @@
+---
+mcp: "Snowflake-Labs/mcp (snowflake-labs-mcp)"
+mcpUrl: https://github.com/Snowflake-Labs/mcp
+testedVersion: "Snowflake MCP Server 2.14.7"
+testedAt: "2026-05-06"
+maintainer: "@giancarloerra"
+category: databases
+status: probed
+tags: [snowflake, cortex, semantic-views, pat, readonly]
+---
+
+# Snowflake (via Snowflake-Labs MCP) — JanuScope Lens
+
+Wraps Snowflake's official MCP server,
+[`Snowflake-Labs/mcp`](https://github.com/Snowflake-Labs/mcp), which
+speaks stdio. The MCP exposes Snowflake DB operations (object
+discovery, raw SQL execution) plus the semantic-view family
+(`query_semantic_view`, `show_semantic_dimensions`, …) for Cortex
+Analyst-style structured analytics.
+
+This lens locks the surface to read-only by:
+
+1. **Blocking** the generic DDL writers `create_object`,
+   `drop_object`, and `create_or_alter_object` (plus defensive
+   globs `create_*` / `drop_*` / `delete_*` / `alter_*`).
+2. **`sqlGuard`-ing `run_snowflake_query`** to reject any SQL that
+   contains a write keyword. The MCP's own description for that tool
+   says "DML and DDL queries are supported", so the keyword guard
+   matters.
+3. **Redacting PII** in result frames — Snowflake returns rows as
+   structured JSON.
+4. **Auditing** every tool call to `~/mcp-audit-snowflake.jsonl`.
+
+## What this lens does
+
+- **`block`** — `create_object`, `drop_object`,
+  `create_or_alter_object` + defensive globs.
+- **`sqlGuard`** — `run_snowflake_query`, `sqlArg: statement`,
+  `readOnly: true`.
+- **`instructions`** — read-only banner pointing the LLM at
+  `list_objects` / `describe_object` / semantic-view tools first,
+  with `run_snowflake_query` as the SELECT-only escape hatch.
+- **`redact`** — field-path PII rules (email, password, api_key,
+  token, secret in both lower-case and Snowflake's default UPPERCASE
+  identifier folding) plus regex fallbacks for SSN, PAN, JWT-shape
+  (which catches PATs leaking through).
+- **`audit`** — JSONL compliance log.
+
+## Tool names this lens assumes
+
+Probed against `Snowflake MCP Server` 2.14.7 on 2026-05-06:
+
+| Tool                             | Kind              | Treatment       |
+| -------------------------------- | ----------------- | --------------- |
+| `list_objects`                   | read (metadata)   | passes through  |
+| `describe_object`                | read (metadata)   | passes through  |
+| `list_semantic_views`            | read              | passes through  |
+| `describe_semantic_view`         | read              | passes through  |
+| `show_semantic_dimensions`       | read              | passes through  |
+| `show_semantic_metrics`          | read              | passes through  |
+| `get_semantic_view_ddl`          | read              | passes through  |
+| `write_semantic_view_query_tool` | helper (no exec)  | passes through  |
+| `query_semantic_view`            | read (analytical) | passes through  |
+| `run_snowflake_query`            | arbitrary SQL     | **sqlGuard ed** |
+| `create_object`                  | DDL write         | **blocked**     |
+| `drop_object`                    | DDL write         | **blocked**     |
+| `create_or_alter_object`         | DDL write         | **blocked**     |
+
+## Prerequisites
+
+1. **A Snowflake account** ([signup.snowflake.com](https://signup.snowflake.com/)).
+   The 30-day trial is sufficient for this lens.
+2. **`uv` / `uvx`** installed locally (the MCP runs via
+   `uvx snowflake-labs-mcp`):
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+3. **A Programmatic Access Token (PAT)**. In Snowsight, navigate to
+   **Governance & security → Users & roles → click your user →
+   Programmatic access tokens → + Generate new token**.
+4. **A PAT-compatible authentication posture** for the user. Snowflake's
+   PAT-auth contract requires either (a) a user-level network policy
+   in place, or (b) an authentication policy granting PAT use without
+   one. Pick whichever fits the deployment; the lens works either way.
+   - **Option (a)** — user-level network policy. Best when the lens
+     runs from a known IP range you want to enforce as a hardening
+     layer:
+     ```sql
+     CREATE NETWORK RULE allow_lens_ip
+       TYPE = IPV4 MODE = INGRESS
+       VALUE_LIST = ('203.0.113.0/24');           -- your range
+     CREATE NETWORK POLICY lens_network_policy
+       ALLOWED_NETWORK_RULE_LIST = ('allow_lens_ip');
+     ALTER USER <YOUR_USER> SET NETWORK_POLICY = lens_network_policy;
+     ```
+   - **Option (b)** — authentication policy that lets PAT auth proceed
+     without a user-level network policy. Best when the lens runs
+     from changing IPs (CI runners, MCP-client laptops, etc.) and
+     the PAT itself is the security boundary. Authentication policies
+     are schema-level objects and must live in a non-personal
+     database; create a small admin database for them:
+     ```sql
+     CREATE DATABASE IF NOT EXISTS LENS_ADMIN;
+     CREATE OR REPLACE AUTHENTICATION POLICY LENS_ADMIN.PUBLIC.pat_no_network_required
+       PAT_POLICY = (NETWORK_POLICY_EVALUATION = ENFORCED_NOT_REQUIRED);
+     ALTER USER <YOUR_USER>
+       SET AUTHENTICATION POLICY LENS_ADMIN.PUBLIC.pat_no_network_required;
+     ```
+     See [SECURITY.md](../../../SECURITY.md#three-layer-model) for the
+     defence-in-depth picture.
+5. **A service-config YAML** for the MCP (it requires one).
+   `services.example.yaml` next to this README is a starter — copy it
+   somewhere stable (e.g. `~/.januscope/snowflake-services.yaml`)
+   and point at it via the `SNOWFLAKE_MCP_CONFIG` env var.
+
+## Customising
+
+All connection details are passed via environment variables (NOT as
+`--password` CLI args, which would leak the PAT into `ps` output).
+These are the names the upstream MCP itself reads — JanuScope does
+not rename or relay them; whatever the user sets in their MCP-client
+config's `env` block reaches the spawned MCP unchanged.
+
+| Variable               | Purpose                                                             |
+| ---------------------- | ------------------------------------------------------------------- |
+| `SNOWFLAKE_ACCOUNT`    | `<orgname>-<accountname>` (e.g. `XYZ-ABC123`)                       |
+| `SNOWFLAKE_USER`       | Your Snowflake username                                             |
+| `SNOWFLAKE_PASSWORD`   | Your PAT — read by the MCP from this env var directly (no CLI flag) |
+| `SNOWFLAKE_ROLE`       | Role to assume (e.g. `ACCOUNTADMIN`)                                |
+| `SNOWFLAKE_WAREHOUSE`  | Warehouse to use (e.g. `COMPUTE_WH`)                                |
+| `SNOWFLAKE_MCP_CONFIG` | Absolute path to your services.yaml                                 |
+
+For production, use a dedicated read-only Snowflake user (database
+role with only `SELECT` on the schemas the LLM should see), and
+ideally key-pair auth instead of PAT — JanuScope inherits whatever
+auth path the MCP supports without rename.
+
+## Usage
+
+```json
+{
+  "mcpServers": {
+    "snowflake": {
+      "command": "npx",
+      "args": ["-y", "januscope", "--config", "snowflake-labs"],
+      "env": {
+        "SNOWFLAKE_ACCOUNT": "XYZ-ABC123",
+        "SNOWFLAKE_USER": "your_user",
+        "SNOWFLAKE_PASSWORD": "<your_PAT>",
+        "SNOWFLAKE_ROLE": "ACCOUNTADMIN",
+        "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
+        "SNOWFLAKE_MCP_CONFIG": "/Users/you/.januscope/snowflake-services.yaml"
+      }
+    }
+  }
+}
+```
+
+## Probe transcript (2026-05-06)
+
+A live `tools/list` against `uvx snowflake-labs-mcp …` returned the
+thirteen tools shown in the table above. Server identity:
+`{"name": "Snowflake MCP Server", "version": "2.14.7"}`. The probe
+was driven against a Snowflake trial account with the
+`pat_no_network_required` authentication policy in place.
+
+## Note on `sql_statement_permissions` (defence in depth)
+
+The Snowflake-Labs MCP's own service-config YAML has a
+`sql_statement_permissions` section that gates which SQL statement
+classes the MCP allows through `run_snowflake_query`. The
+`services.example.yaml` shipped next to this README sets all write
+classes to `False` (Alter, Copy, Create, Delete, Drop, Insert,
+Merge, TruncateTable, Update). JanuScope's `sqlGuard` is the proxy
+layer; the MCP-level config is the second layer; a read-only
+Snowflake role is the third layer that physically prevents writes.
+
+## Changelog
+
+- **2026-05-06** — Initial contribution (@giancarloerra). Probed
+  against Snowflake MCP Server 2.14.7 on a Snowflake 30-day trial
+  account with PAT auth.

--- a/lenses/databases/snowflake-labs/config.yaml
+++ b/lenses/databases/snowflake-labs/config.yaml
@@ -1,0 +1,104 @@
+# Snowflake (via Snowflake-Labs MCP) — JanuScope Lens
+#
+# Wraps Snowflake's official MCP server (uvx snowflake-labs-mcp) which
+# speaks stdio. Authentication uses Snowflake Programmatic Access Tokens
+# (PATs) passed through SNOWFLAKE_PASSWORD per the MCP's documented
+# convention (the deprecated --pat flag is no longer used).
+#
+# Tools observed in live tools/list (Snowflake MCP Server 2.14.7,
+# 2026-05-06):
+#   READ : list_objects, describe_object, list_semantic_views,
+#          describe_semantic_view, show_semantic_dimensions,
+#          show_semantic_metrics, get_semantic_view_ddl,
+#          write_semantic_view_query_tool (returns a query string),
+#          query_semantic_view
+#   ARBITRARY-SQL: run_snowflake_query
+#                  ("DML and DDL queries are supported" per its own
+#                   description → wrap in sqlGuard)
+#   GENERIC-DDL-WRITE: create_object, drop_object,
+#                      create_or_alter_object → blocked outright
+
+target:
+  command: uvx
+  args:
+    - snowflake-labs-mcp
+    - --service-config-file
+    - "${SNOWFLAKE_MCP_CONFIG}"
+  # All connection parameters (account / user / password / role /
+  # warehouse) are passed via the upstream MCP's documented env-var
+  # contract: SNOWFLAKE_ACCOUNT / SNOWFLAKE_USER / SNOWFLAKE_PASSWORD
+  # / SNOWFLAKE_ROLE / SNOWFLAKE_WAREHOUSE. Doing this via env (not
+  # CLI args) keeps the PAT out of `ps` listings. JanuScope inherits
+  # whatever the user sets in their MCP-client config env block — no
+  # rename, no relay through target.env.
+
+# firstRun: approve
+
+block:
+  # Generic DDL writers — `create_object` / `drop_object` /
+  # `create_or_alter_object` accept any object type (database,
+  # schema, table, view, stream, task, …). Block all three at the
+  # proxy layer; the LLM has no business mutating schema.
+  - create_object
+  - drop_object
+  - create_or_alter_object
+  # Defensive future-proofing for any new write-shaped object tools
+  # that follow the existing naming convention.
+  - "create_*"
+  - "drop_*"
+  - "delete_*"
+  - "alter_*"
+
+# `run_snowflake_query` is the catch-all SQL execution tool. Its own
+# description states "DML and DDL queries are supported", so layer
+# keyword-level write rejection at the proxy. Defence in depth on top
+# of the `sql_statement_permissions` policy in the upstream services
+# YAML (which can be set to forbid Insert/Update/Delete/Drop/Create
+# at the MCP layer too — see this lens's README for a sample).
+sqlGuard:
+  tools:
+    - run_snowflake_query
+  sqlArg: statement
+  readOnly: true
+
+instructions: |
+  READ-ONLY Snowflake. This proxy wraps the Snowflake-Labs MCP plus a
+  proxy-side block list and sqlGuard.
+  - Use `list_objects` / `describe_object` for schema discovery
+    (databases, schemas, tables, views, stages, …).
+  - Use `list_semantic_views` / `describe_semantic_view` /
+    `show_semantic_dimensions` / `show_semantic_metrics` /
+    `get_semantic_view_ddl` for semantic-view introspection.
+  - Use `query_semantic_view` to query a semantic view by name with
+    DIMENSIONS / METRICS arguments — the canonical analytical path.
+  - Use `run_snowflake_query` for SELECT and WITH queries; the proxy
+    rejects any statement containing INSERT / UPDATE / DELETE / DROP
+    / CREATE / ALTER / TRUNCATE / GRANT / etc.
+  - `create_object` / `drop_object` / `create_or_alter_object` are
+    blocked outright. The LLM is not authorised to mutate Snowflake
+    schema through this lens.
+
+redact:
+  rules:
+    # PII field paths in JSON tool results. Snowflake returns rows
+    # in a structured JSON shape via run_snowflake_query.
+    - field: "**.email"
+    - field: "**.EMAIL"
+    - field: "**.password"
+    - field: "**.PASSWORD"
+    - field: "**.api_key"
+    - field: "**.API_KEY"
+    - field: "**.token"
+    - field: "**.TOKEN"
+    - field: "**.secret"
+    - field: "**.SECRET"
+    # Value-shape fallbacks for free-text columns and result rows.
+    - regex: '\b\d{3}-\d{2}-\d{4}\b' # US SSN
+    - regex: '\b(?:\d[ -]*?){13,16}\b' # PAN-shaped digit run
+    - regex: '\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b' # JWT (incl PAT shape)
+  replacement: "[REDACTED]"
+  applyTo: text
+
+audit:
+  sink: "~/mcp-audit-snowflake.jsonl"
+  logRawArgs: false

--- a/lenses/databases/snowflake-labs/services.example.yaml
+++ b/lenses/databases/snowflake-labs/services.example.yaml
@@ -1,0 +1,36 @@
+# Sample service-config for the Snowflake-Labs MCP server.
+# Copy this file somewhere stable (e.g. ~/.januscope/snowflake-services.yaml),
+# adjust the sql_statement_permissions to match your read-only intent,
+# and point the lens at it via the SNOWFLAKE_MCP_CONFIG env var.
+#
+# This sample enables the basic object/query/semantic tools and locks
+# down sql_statement_permissions to read-only. JanuScope's sqlGuard
+# layer rejects writes again at the proxy so this is defence-in-depth.
+agent_services: []
+search_services: []
+analyst_services: []
+
+other_services:
+  object_manager: True
+  query_manager: True
+  semantic_manager: True
+
+sql_statement_permissions:
+  - Alter: False
+  - Command: True
+  - Comment: True
+  - Commit: True
+  - Copy: False
+  - Create: False
+  - Delete: False
+  - Describe: True
+  - Drop: False
+  - Insert: False
+  - Merge: False
+  - Rollback: True
+  - Select: True
+  - Transaction: True
+  - TruncateTable: False
+  - Unknown: False
+  - Update: False
+  - Use: True

--- a/lenses/databases/sqlite-panasenco/config.yaml
+++ b/lenses/databases/sqlite-panasenco/config.yaml
@@ -33,7 +33,10 @@ target:
     # Optional: metadata file with canned queries
     # - "--metadata"
     # - "${SQLITE_METADATA_PATH}"
-  env: {}
+  # No env block. mcp-sqlite takes the SQLite path as a positional
+  # CLI argument with no env-var equivalent; ${SQLITE_DB_PATH} is the
+  # lens-introduced name for that positional. See lenses/CONTRIBUTING.md
+  # for the rule on `${VAR}` in target.args.
 
 # Data-sensitivity label — tags audit records and prepends a classification
 # banner to the instructions the LLM sees.

--- a/lenses/saas/atlassian-official/config.yaml
+++ b/lenses/saas/atlassian-official/config.yaml
@@ -31,7 +31,9 @@ target:
     - "-y"
     - "mcp-remote"
     - "https://mcp.atlassian.com/v1/mcp"
-  env: {}
+  # No env block. mcp-remote handles OAuth interactively on first
+  # launch; no operator-supplied env vars are required at the lens
+  # level. See lenses/CONTRIBUTING.md for the transparency rule.
 
 # Data-sensitivity label — tags audit records and prepends a classification
 # banner to the instructions the LLM sees.

--- a/lenses/saas/linear-remote/config.yaml
+++ b/lenses/saas/linear-remote/config.yaml
@@ -24,7 +24,9 @@ target:
     - "-y"
     - "mcp-remote"
     - "https://mcp.linear.app/sse"
-  env: {}
+  # No env block. mcp-remote handles OAuth interactively on first
+  # launch; no operator-supplied env vars are required at the lens
+  # level. See lenses/CONTRIBUTING.md for the transparency rule.
 
 # Data-sensitivity label — tags audit records and prepends a classification
 # banner to the instructions the LLM sees.

--- a/lenses/saas/notion-official/config.yaml
+++ b/lenses/saas/notion-official/config.yaml
@@ -22,7 +22,9 @@ target:
     - "-y"
     - "mcp-remote"
     - "https://mcp.notion.com/mcp"
-  env: {}
+  # No env block. mcp-remote handles OAuth interactively on first
+  # launch; no operator-supplied env vars are required at the lens
+  # level. See lenses/CONTRIBUTING.md for the transparency rule.
 
 # Data-sensitivity label — tags audit records and prepends a classification
 # banner to the instructions the LLM sees.

--- a/lenses/saas/supabase-cloud/README.md
+++ b/lenses/saas/supabase-cloud/README.md
@@ -1,0 +1,139 @@
+---
+mcp: "Supabase hosted MCP server"
+mcpUrl: https://github.com/supabase-community/supabase-mcp
+testedVersion: "supabase 0.8.1 (hosted at mcp.supabase.com)"
+testedAt: "2026-05-06"
+maintainer: "@giancarloerra"
+category: saas
+status: probed
+tags: [supabase, postgres, hosted, mcp-remote, readonly, pat]
+---
+
+# Supabase Cloud (hosted) — JanuScope Lens
+
+Wraps Supabase's **hosted** MCP server at `https://mcp.supabase.com/mcp`
+via [`mcp-remote`](https://github.com/geelen/mcp-remote). The hosted
+MCP exposes a much wider surface than the self-host variant
+(~30 tools spanning Account / Project / Database / Edge Functions /
+Branching), so this lens has a correspondingly larger block list.
+
+For the **local-development** Supabase MCP that ships with the CLI
+(`supabase start` → `http://127.0.0.1:54321/mcp`), use the
+`supabase-selfhost` lens instead. That one has a smaller surface
+(~11 tools) and no auth.
+
+## What this lens does
+
+- **`block`** — every write-shaped tool: `create_project`,
+  `pause_project`, `restore_project`, `apply_migration`,
+  `deploy_edge_function`, `create_branch` / `delete_branch` /
+  `merge_branch` / `reset_branch` / `rebase_branch`. Plus
+  defensive globs (`create_*`, `delete_*`, `update_*`, `deploy_*`)
+  to catch future write-shaped additions.
+- **`sqlGuard`** — `execute_sql`, `sqlArg: query`, `readOnly: true`.
+- **`instructions`** — read-only banner with the canonical tool path.
+- **`redact`** — PII field paths + DSN / SSN / PAN / JWT regex
+  fallbacks.
+- **`audit`** — JSONL compliance log at
+  `~/mcp-audit-supabase-cloud.jsonl`.
+
+The lens uses `mcp-remote` to bridge HTTP→stdio. Auth is
+non-interactive via Personal Access Token in the
+`Authorization: Bearer` header.
+
+## Tool names this lens assumes
+
+Probed against Supabase hosted MCP `0.8.1` on 2026-05-06 with
+`?read_only=true`:
+
+| Tool                        | Kind             | Treatment       |
+| --------------------------- | ---------------- | --------------- |
+| `search_docs`               | read (KB)        | passes through  |
+| `list_organizations`        | read             | passes through  |
+| `get_organization`          | read             | passes through  |
+| `list_projects`             | read             | passes through  |
+| `get_project`               | read             | passes through  |
+| `get_cost` / `confirm_cost` | read (pricing)   | passes through  |
+| `list_tables`               | read (metadata)  | passes through  |
+| `list_extensions`           | read (metadata)  | passes through  |
+| `list_migrations`           | read (metadata)  | passes through  |
+| `get_logs`                  | read (logs)      | passes through  |
+| `get_advisors`              | read (advice)    | passes through  |
+| `get_project_url`           | read (metadata)  | passes through  |
+| `get_publishable_keys`      | read (anon keys) | passes through  |
+| `generate_typescript_types` | read (schema)    | passes through  |
+| `list_edge_functions`       | read             | passes through  |
+| `get_edge_function`         | read             | passes through  |
+| `list_branches`             | read             | passes through  |
+| `execute_sql`               | arbitrary SQL    | **sqlGuard ed** |
+| `apply_migration`           | DDL write        | **blocked**     |
+| `create_project`            | account write    | **blocked**     |
+| `pause_project`             | account write    | **blocked**     |
+| `restore_project`           | account write    | **blocked**     |
+| `deploy_edge_function`      | code deploy      | **blocked**     |
+| `create_branch`             | branch write     | **blocked**     |
+| `delete_branch`             | branch write     | **blocked**     |
+| `merge_branch`              | branch write     | **blocked**     |
+| `reset_branch`              | branch write     | **blocked**     |
+| `rebase_branch`             | branch write     | **blocked**     |
+
+## Prerequisites
+
+1. **A Supabase account** ([supabase.com/dashboard/sign-up](https://supabase.com/dashboard/sign-up)). The free tier covers the lens probe.
+2. **A Personal Access Token (PAT)**. In the Supabase dashboard,
+   navigate to **[Account → Access Tokens → Generate new token](https://supabase.com/dashboard/account/tokens)**,
+   copy the value (only shown once). The token starts with `sbp_`.
+3. **Node.js 20+** for `mcp-remote`.
+
+## Customising
+
+The lens reads the PAT from the `SUPABASE_ACCESS_TOKEN` environment variable.
+JanuScope substitutes `${SUPABASE_ACCESS_TOKEN}` in `target.args` at startup.
+
+To scope the MCP to a single project (recommended for production
+deployments), add `&project_ref=<project-id>` to the URL in
+`target.args`. Project-scoping disables the cross-account tools
+(`list_projects`, `list_organizations`, etc.) and locks the session
+to a single project.
+
+## Usage
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": ["-y", "januscope", "--config", "supabase-cloud"],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "sbp_your_token_here"
+      }
+    }
+  }
+}
+```
+
+Replace `sbp_your_token_here` with your Supabase PAT.
+
+## Probe transcript (2026-05-06)
+
+A live `tools/list` against the bridged stdio session returned the
+twenty-nine tools shown in the table above. Server identity:
+`{"name": "supabase", "title": "Supabase", "version": "0.8.1"}`. The
+probe was driven against the live `mcp.supabase.com` endpoint with
+`?read_only=true` and PAT auth. After the lens's block list applies,
+**18 tools** remain visible to the LLM (read-side); `execute_sql`
+additionally has `sqlGuard` on its `query` argument.
+
+## Note on read-only flag vs proxy block list
+
+Supabase's `?read_only=true` URL flag DOES disable execution of write
+operations at the data-path level (per the official docs), but the
+MCP still surfaces those tools in `tools/list`. The proxy-side block
+list ensures the LLM never sees write-shaped tool names in the first
+place — same defence-in-depth philosophy as the `neon-cloud` lens.
+
+## Changelog
+
+- **2026-05-06** — Initial contribution (@giancarloerra). Probed
+  against Supabase hosted MCP 0.8.1 with PAT auth and
+  `?read_only=true`.

--- a/lenses/saas/supabase-cloud/config.yaml
+++ b/lenses/saas/supabase-cloud/config.yaml
@@ -1,0 +1,126 @@
+# Supabase Cloud (hosted) — JanuScope Lens
+#
+# Wraps Supabase's hosted MCP server at https://mcp.supabase.com/mcp
+# via `mcp-remote`. Uses Personal Access Token auth in the
+# `Authorization: Bearer` header — non-interactive, suitable for
+# MCP-client configs / CI.
+#
+# This is the FULL hosted surface (~30 tools spanning Account /
+# Database / Debugging / Edge Functions / Branching). For the
+# reduced local-development surface, see the `supabase-selfhost`
+# lens which wraps the CLI's local stack.
+#
+# Tools observed in live tools/list (supabase 0.8.1, ?read_only=true,
+# 2026-05-06):
+#   ACCOUNT (read): search_docs, list_organizations, get_organization,
+#                   list_projects, get_project, get_cost, confirm_cost
+#   ACCOUNT (write→blocked): create_project, pause_project, restore_project
+#   DATABASE (read): list_tables, list_extensions, list_migrations,
+#                    get_logs, get_advisors, get_project_url,
+#                    get_publishable_keys, generate_typescript_types
+#   DATABASE (arbitrary SQL→sqlGuard): execute_sql
+#   DATABASE (DDL→blocked): apply_migration
+#   EDGE FUNCTIONS (read): list_edge_functions, get_edge_function
+#   EDGE FUNCTIONS (deploy→blocked): deploy_edge_function
+#   BRANCHING (read): list_branches
+#   BRANCHING (write→blocked): create_branch, delete_branch,
+#                              merge_branch, reset_branch, rebase_branch
+
+target:
+  command: npx
+  args:
+    - "-y"
+    - "mcp-remote"
+    - "https://mcp.supabase.com/mcp?read_only=true"
+    - "--header"
+    - "Authorization:Bearer ${SUPABASE_ACCESS_TOKEN}"
+    - "--transport"
+    - "http-only"
+
+classification: internal
+
+# firstRun: approve
+
+block:
+  # Project lifecycle writes — even in "read only mode" the MCP
+  # surfaces these tools; explicit proxy-side block hides them
+  # from the LLM.
+  - create_project
+  - pause_project
+  - restore_project
+  # DDL / migration write
+  - apply_migration
+  # Code-deployment write — deploys an Edge Function from caller-
+  # supplied source. Treat as the most dangerous write tool: it
+  # publishes runnable code into the Supabase project.
+  - deploy_edge_function
+  # Branching writes
+  - create_branch
+  - delete_branch
+  - merge_branch
+  - reset_branch
+  - rebase_branch
+  # Defensive future-proofing: any new project / branch / function /
+  # storage WRITE that follows the existing naming convention.
+  - "create_*"
+  - "delete_*"
+  - "update_*"
+  - "deploy_*"
+
+# `execute_sql` is the catch-all SQL execution tool. Even with
+# `?read_only=true` enforcing read-only at the database role, layer
+# keyword-level guard at the proxy as defence in depth.
+sqlGuard:
+  tools:
+    - execute_sql
+  sqlArg: query
+  readOnly: true
+
+instructions: |
+  READ-ONLY hosted Supabase. This proxy wraps mcp.supabase.com with
+  the `?read_only=true` flag plus proxy-layer block + sqlGuard.
+
+  Read paths the LLM should use:
+  - `list_organizations` / `list_projects` / `get_project` for orientation.
+  - `list_tables` / `list_extensions` / `list_migrations` for schema
+    discovery; `generate_typescript_types` for a typed schema snapshot.
+  - `execute_sql` for SELECT / WITH queries; the proxy rejects any
+    statement containing INSERT / UPDATE / DELETE / DROP / CREATE /
+    ALTER / TRUNCATE / GRANT / etc.
+  - `get_logs` / `get_advisors` for diagnostic introspection.
+  - `list_branches` (read), `list_edge_functions` / `get_edge_function`
+    (read).
+
+  Blocked tools (do not attempt; the proxy refuses the call and
+  the attempt is audited):
+  - `create_project` / `pause_project` / `restore_project`
+  - `apply_migration` (DDL)
+  - `deploy_edge_function` (code publish)
+  - `create_branch` / `delete_branch` / `merge_branch` /
+    `reset_branch` / `rebase_branch`
+
+  `get_publishable_keys` returns CLIENT-SAFE keys only. The
+  server-side `service_role` key is never exposed by this MCP.
+
+redact:
+  rules:
+    # PII field paths in JSON tool results.
+    - field: "**.email"
+    - field: "**.password"
+    - field: "**.password_hash"
+    - field: "**.api_key"
+    - field: "**.apiKey"
+    - field: "**.token"
+    - field: "**.secret"
+    # Connection-string-shaped values (Postgres DSN).
+    - regex: "\\bpostgres(ql)?://[^\\s]*?:[^\\s@]+@[^\\s/]+"
+    # Value-shape fallbacks.
+    - regex: '\b\d{3}-\d{2}-\d{4}\b' # US SSN
+    - regex: '\b(?:\d[ -]*?){13,16}\b' # PAN-shaped digit run
+    - regex: '\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b' # JWT
+  replacement: "[REDACTED]"
+  applyTo: text
+
+audit:
+  sink: "~/mcp-audit-supabase-cloud.jsonl"
+  logRawArgs: false


### PR DESCRIPTION
## Summary

Five new bundled database / cloud-data Lenses, every one authored against a live MCP and a real backend, every `tools/list` captured against the running server, and `sqlGuard` rejection of write SQL verified end-to-end. Lens count goes **15 → 20**. Plus a small round of cross-lens hygiene: the lens transparency rule is tightened to cover `${VAR}` substitutions in `target.args`, the empty `env: {}` noise is stripped from five older lenses, and the README's Quick Start gets an honest install-prerequisite callout for the three lenses that need a one-time local CLI install.

## New lenses

| Lens | MCP | Auth | Tools upstream → after JanuScope filter | sqlGuard runtime test |
|---|---|---|---|---|
| `neon-cloud` (databases/) | mcp.neon.tech (mcp-server-neon 1.0.0) | API key in `Authorization: Bearer` header | 18 → 17 (`get_connection_string` blocked: DSN credential leak) | `DELETE FROM whatever` → REJECTED |
| `supabase-cloud` (saas/) | mcp.supabase.com (supabase 0.8.1) | PAT in `Authorization: Bearer` header | 29 → 19 (10 writes blocked + defensive create_/delete_/update_/deploy_ globs) | `DROP TABLE foo` → REJECTED |
| `snowflake-labs` (databases/) | Snowflake-Labs/mcp via `uvx` (Snowflake MCP Server 2.14.7) | PAT via `SNOWFLAKE_PASSWORD` env (no CLI exposure) | 13 → 10 (3 generic DDL writers + globs blocked) | `DROP TABLE foo` → REJECTED |
| `aurora-dsql` (databases/) | awslabs.aurora-dsql-mcp-server 1.27.0 | AWS IAM via SDK credential chain | 6 → 6 (MCP-side default read-only mode) | `DELETE` → REJECTED |
| `redshift` (databases/) | awslabs.redshift-mcp-server 1.27.0 | AWS IAM via SDK credential chain | 6 → 6 (`execute_query` sqlGuard'd) | `DROP TABLE foo` → REJECTED |

## Maintenance polish (same commit)

- **Lens transparency rule tightened** in `lenses/CONTRIBUTING.md`. The rule now explicitly covers `${VAR}` substitutions inside `target.args` (not just `target.env`), with a worked Supabase-Cloud example showing the right way (`SUPABASE_ACCESS_TOKEN`, ecosystem-standard) vs. the wrong way (a freshly-invented `SUPABASE_PAT`).
- **`env: {}` noise stripped** from `redis-official`, `sqlite-panasenco`, `notion-official`, `atlassian-official`, `linear-remote`. Each carries a comment explaining why no env block is needed.
- **`redis-official` simplified**: dropped `--url ${REDIS_URL}` from `target.args` after verifying online that `redis-mcp-server` reads `REDIS_URL` directly from process env. The lens now relies on env propagation, no rename, no redundant pass-through.
- **Snowflake lens hardened**: PAT no longer passed through `--password` CLI arg (would leak via `ps`); now flows through the upstream MCP's `SNOWFLAKE_PASSWORD` env var contract.
- **Snowflake README rewritten** to frame the auth-policy step as standard Snowflake security configuration (option (a) network policy / option (b) authentication policy with `NETWORK_POLICY_EVALUATION = ENFORCED_NOT_REQUIRED`), not a trial-account workaround.
- **Redshift README tightened**: `<your-iam-principal>` placeholder, IAM policy listed as a normal prerequisite.
- **README Quick Start** gets a small install-prerequisite callout: most lenses run via `npx`/`uvx`, three need a one-time local install (`dab` / `sql` / `docker`).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 405 / 405 passing
- [x] `npm run validate:lenses` — 20 / 20 valid
- [x] `npm run build` clean
- [x] `coderabbit review` — actioned during build (env-var rename, README polish, false-positive count miscounts noted)
- [x] `snyk code test` — same 7 pre-existing findings, all already documented in `.snyk`; this PR adds zero source code, only YAML + Markdown
- [x] Live `tools/list` captured against a running MCP for each new lens (transcripts referenced in each lens README's "Probe transcript" section)
- [x] Live `tools/call` with a write payload verified rejected by `sqlGuard` end-to-end on each lens that has one (Aurora DSQL, Neon, Redshift, Snowflake, Supabase Cloud)

## Version expectations

Single `fix:` commit ⇒ release-it bumps **`v0.4.1` → `v0.4.2`** (patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five bundled lenses: Neon Cloud, Snowflake Labs, Aurora DSQL, Redshift, and Supabase Cloud.
  * Added a quick-browse helper for listing and inspecting bundled lenses.

* **Documentation**
  * Expanded lens catalog to 20 entries and updated the access-mode=restricted comparison table.
  * Clarified env var propagation and added “About the env block” guidance.
  * Added lens transparency guidance and comprehensive READMEs for each new lens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->