### PR TITLE
chore(deps): update mysql2 to 3.24.4

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_filters:
+    - "**/package-lock.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4249,9 +4249,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
-      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.4.tgz",
+      "integrity": "sha512-A2olluVlj0mvgyIRRISMEzXc51m+21mRtcMVjJyIpt2GG98+XrC9m9HzsqcMsX2LcnfccJvY5NB22g8fENBnOA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
## Summary

- updates the locked `mysql2` version from 3.24.2 to 3.24.4
- preserves `mysql2` as an optional dependency
- configures CodeRabbit to review `package-lock.json` so dependency-only pull requests receive an actual review

Supersedes #51 without its incorrect required-dependency lockfile entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added repository review configuration for automated code review tooling.
  - Updated the locked MySQL client package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->